### PR TITLE
refactor: replacing exceptions with `std::expected`

### DIFF
--- a/docs/CodeStyle.md
+++ b/docs/CodeStyle.md
@@ -11,6 +11,8 @@ contributors to the `BenBot` project.
 * Prefer modern facilities: use `auto`, `using`, etc.
 * West const. `const auto* foo` or `auto* const foo`.
 * For boolean operators `&&`, `||` and `!`, we prefer the alternate tokens `and`, `or`, and `not`. This makes the code more readable. `!` is much easier to miss than `not`.
+* Always prefer standard library algorithms or range-based for loops over raw `for` loops whenever possible.
+* When working with monadic objects such as `std::optional` or `std::expected`, prefer to use the monadic operations over checking `has_value()` whenever possible.
 * Prefer to use standard library mechanisms over reinventing the wheel.
 * Always prefer brackets for initialization.
 For example, a constructor init list:

--- a/libchess/include/libchess/board/File.hpp
+++ b/libchess/include/libchess/board/File.hpp
@@ -20,10 +20,11 @@
 #pragma once
 
 #include <cctype> // IWYU pragma: keep - for std::tolower()
+#include <expected>
 #include <format>
 #include <libchess/board/BitboardIndex.hpp>
 #include <magic_enum/magic_enum.hpp>
-#include <stdexcept>
+#include <string>
 
 namespace chess::board {
 
@@ -46,13 +47,12 @@ enum class File : BitboardIndex {
 /** Interprets the given character as a file.
     This function recognizes upper- or lowercase file letters.
 
-    @throws std::invalid_argument An exception will be thrown if a file
-    cannot be parsed correctly from the input character.
+    If the input string cannot be parsed correctly, returns an explanatory error string.
 
     @ingroup board
     @see File
  */
-[[nodiscard, gnu::const]] constexpr File file_from_char(char character);
+[[nodiscard]] std::expected<File, std::string> file_from_char(char character);
 
 /** Converts the file enumeration to its single-character representation.
 
@@ -104,7 +104,7 @@ struct std::formatter<chess::board::File> final {
 
 namespace chess::board {
 
-constexpr File file_from_char(char character)
+inline std::expected<File, std::string> file_from_char(char character)
 {
     switch (character) {
         case 'a': [[fallthrough]];
@@ -132,9 +132,10 @@ constexpr File file_from_char(char character)
         case 'H': return File::H;
 
         default:
-            throw std::invalid_argument {
-                std::format("Cannot parse File from character: {}", character)
-            };
+            return std::unexpected(
+                std::format(
+                    "Cannot parse File from character: {}",
+                    character));
     }
 }
 

--- a/libchess/include/libchess/board/Rank.hpp
+++ b/libchess/include/libchess/board/Rank.hpp
@@ -20,10 +20,12 @@
 #pragma once
 
 #include <cassert>
+#include <expected>
 #include <format>
 #include <libchess/board/BitboardIndex.hpp>
 #include <libchess/pieces/Colors.hpp>
 #include <stdexcept>
+#include <string>
 #include <string_view>
 #include <utility>
 
@@ -74,7 +76,7 @@ template <Color Side>
     @ingroup board
     @see Rank
  */
-[[nodiscard, gnu::const]] constexpr Rank rank_from_char(char character);
+[[nodiscard]] std::expected<Rank, std::string> rank_from_char(char character);
 
 /** Converts the rank to its single-character representation (as an integer).
 
@@ -160,7 +162,7 @@ constexpr Rank prev_pawn_rank(const Rank rank) noexcept
     }
 }
 
-constexpr Rank rank_from_char(const char character)
+inline std::expected<Rank, std::string> rank_from_char(const char character)
 {
     switch (character) {
         case '1': return Rank::One;
@@ -173,9 +175,10 @@ constexpr Rank rank_from_char(const char character)
         case '8': return Rank::Eight;
 
         default:
-            throw std::invalid_argument {
-                std::format("Cannot parse Rank from character: {}", character)
-            };
+            return std::unexpected(
+                std::format(
+                    "Cannot parse Rank from character: {}",
+                    character));
     }
 }
 

--- a/libchess/include/libchess/board/Rank.hpp
+++ b/libchess/include/libchess/board/Rank.hpp
@@ -24,7 +24,6 @@
 #include <format>
 #include <libchess/board/BitboardIndex.hpp>
 #include <libchess/pieces/Colors.hpp>
-#include <stdexcept>
 #include <string>
 #include <string_view>
 #include <utility>
@@ -70,8 +69,7 @@ template <Color Side>
 
 /** Interprets the given character as a rank.
 
-    @throws std::invalid_argument An exception will be thrown if a rank
-    cannot be parsed correctly from the input character.
+    If the input string cannot be parsed correctly, returns an explanatory error string.
 
     @ingroup board
     @see Rank

--- a/libchess/include/libchess/board/Square.hpp
+++ b/libchess/include/libchess/board/Square.hpp
@@ -30,12 +30,13 @@
 #include <cassert>
 #include <compare>
 #include <cstddef> // IWYU pragma: keep - for size_t
+#include <expected>
 #include <format>
 #include <libchess/board/BitboardIndex.hpp>
 #include <libchess/board/File.hpp>
 #include <libchess/board/Rank.hpp>
 #include <libchess/util/Math.hpp>
-#include <stdexcept>
+#include <string>
 #include <string_view>
 #include <utility>
 
@@ -85,10 +86,9 @@ struct Square final {
         This method recognizes either upper- or lower-case file letters. This method
         always throws if the input string is not 2 characters long.
 
-        @throws std::invalid_argument An exception will be thrown if a square cannot be
-        parsed correctly from the input string.
+        If the input string cannot be parsed correctly, returns an explanatory error string.
      */
-    [[nodiscard, gnu::const]] static Square from_string(std::string_view text);
+    [[nodiscard]] static std::expected<Square, std::string> from_string(std::string_view text);
 
     /** Returns the bitboard bit index for this square.
         The returned index will be in the range ``[0,63]``.
@@ -232,24 +232,26 @@ constexpr bool Square::is_light() const noexcept
         std::to_underlying(rank) + std::to_underlying(file));
 }
 
-inline Square Square::from_string(const std::string_view text)
+inline std::expected<Square, std::string> Square::from_string(const std::string_view text)
 {
-    if (text.length() != 2uz)
-        throw std::invalid_argument {
-            std::format("Cannot parse Square from invalid input string: {}", text)
-        };
+    if (text.length() != 2uz) {
+        return std::unexpected(
+            std::format(
+                "Cannot parse Square from invalid input string: {}",
+                text));
+    }
 
     const auto rank = rank_from_char(text.back());
 
     if (not rank.has_value())
-        throw std::invalid_argument { rank.error() };
+        return std::unexpected(rank.error());
 
     const auto file = file_from_char(text.front());
 
     if (not file.has_value())
-        throw std::invalid_argument { file.error() };
+        return std::unexpected(file.error());
 
-    return {
+    return Square {
         .file = file.value(),
         .rank = rank.value()
     };

--- a/libchess/include/libchess/board/Square.hpp
+++ b/libchess/include/libchess/board/Square.hpp
@@ -244,8 +244,13 @@ inline Square Square::from_string(const std::string_view text)
     if (not rank.has_value())
         throw std::invalid_argument { rank.error() };
 
+    const auto file = file_from_char(text.front());
+
+    if (not file.has_value())
+        throw std::invalid_argument { file.error() };
+
     return {
-        .file = file_from_char(text.front()),
+        .file = file.value(),
         .rank = rank.value()
     };
 }

--- a/libchess/include/libchess/board/Square.hpp
+++ b/libchess/include/libchess/board/Square.hpp
@@ -88,7 +88,7 @@ struct Square final {
         @throws std::invalid_argument An exception will be thrown if a square cannot be
         parsed correctly from the input string.
      */
-    [[nodiscard, gnu::const]] static constexpr Square from_string(std::string_view text);
+    [[nodiscard, gnu::const]] static Square from_string(std::string_view text);
 
     /** Returns the bitboard bit index for this square.
         The returned index will be in the range ``[0,63]``.
@@ -232,16 +232,21 @@ constexpr bool Square::is_light() const noexcept
         std::to_underlying(rank) + std::to_underlying(file));
 }
 
-constexpr Square Square::from_string(const std::string_view text)
+inline Square Square::from_string(const std::string_view text)
 {
     if (text.length() != 2uz)
         throw std::invalid_argument {
             std::format("Cannot parse Square from invalid input string: {}", text)
         };
 
+    const auto rank = rank_from_char(text.back());
+
+    if (not rank.has_value())
+        throw std::invalid_argument { rank.error() };
+
     return {
         .file = file_from_char(text.front()),
-        .rank = rank_from_char(text.back())
+        .rank = rank.value()
     };
 }
 

--- a/libchess/include/libchess/board/Square.hpp
+++ b/libchess/include/libchess/board/Square.hpp
@@ -83,8 +83,7 @@ struct Square final {
 
     /** Creates a square from a string in algebraic notation, such as "A1", "H4", etc.
 
-        This method recognizes either upper- or lower-case file letters. This method
-        always throws if the input string is not 2 characters long.
+        This method recognizes either upper- or lower-case file letters.
 
         If the input string cannot be parsed correctly, returns an explanatory error string.
      */
@@ -241,20 +240,16 @@ inline std::expected<Square, std::string> Square::from_string(const std::string_
                 text));
     }
 
-    const auto rank = rank_from_char(text.back());
-
-    if (not rank.has_value())
-        return std::unexpected(rank.error());
-
-    const auto file = file_from_char(text.front());
-
-    if (not file.has_value())
-        return std::unexpected(file.error());
-
-    return Square {
-        .file = file.value(),
-        .rank = rank.value()
-    };
+    return rank_from_char(text.back())
+        .and_then([fileChar = text.front()](const Rank rankToUse) {
+            return file_from_char(fileChar)
+                .transform([rankToUse](const File fileToUse) {
+                    return Square {
+                        .file = fileToUse,
+                        .rank = rankToUse
+                    };
+                });
+        });
 }
 
 constexpr Square get_en_passant_captured_square(

--- a/libchess/include/libchess/moves/MoveGen.hpp
+++ b/libchess/include/libchess/moves/MoveGen.hpp
@@ -227,14 +227,11 @@ namespace detail {
              | std::views::transform([promotedType](const auto& tuple) {
                    const auto [starting, target] = tuple;
 
-                   if (promotedType.has_value())
-                       return Move {
-                           starting, target, PieceType::Pawn, promotedType.value()
-                       };
-
-                   return Move {
-                       starting, target, PieceType::Pawn
-                   };
+                   return promotedType
+                       .transform([starting, target](const PieceType type) {
+                           return Move { starting, target, PieceType::Pawn, type };
+                       })
+                       .value_or(Move { starting, target, PieceType::Pawn });
                });
     }
 
@@ -302,28 +299,25 @@ namespace detail {
         // at most 2 captures are possible at a time
         using EPMoves = beman::inplace_vector<Move, 2uz>;
 
-        if (not position.enPassantTargetSquare.has_value()) {
-            [[likely]];
-            return EPMoves {};
-        }
+        return position.enPassantTargetSquare
+            .transform([&position](const Square targetSquare) {
+                const auto targetSquareBoard = Bitboard::from_square(targetSquare);
 
-        const auto targetSquare = *position.enPassantTargetSquare;
+                const auto startSquares = shifts::pawn_inv_capture_east<Side>(targetSquareBoard)
+                                        | shifts::pawn_inv_capture_west<Side>(targetSquareBoard);
 
-        const auto targetSquareBoard = Bitboard::from_square(targetSquare);
-
-        const auto startSquares = shifts::pawn_inv_capture_east<Side>(targetSquareBoard)
-                                | shifts::pawn_inv_capture_west<Side>(targetSquareBoard);
-
-        return (position.pieces_for<Side>().pawns & startSquares).squares()
-             | std::views::transform([targetSquare](const Square square) {
-                   return Move {
-                       square, targetSquare, PieceType::Pawn
-                   };
-               })
-             | std::views::filter([&position](const Move& move) {
-                   return position.is_legal(move);
-               })
-             | std::ranges::to<EPMoves>();
+                return (position.pieces_for<Side>().pawns & startSquares).squares()
+                     | std::views::transform([targetSquare](const Square square) {
+                           return Move {
+                               square, targetSquare, PieceType::Pawn
+                           };
+                       })
+                     | std::views::filter([&position](const Move& move) {
+                           return position.is_legal(move);
+                       })
+                     | std::ranges::to<EPMoves>();
+            })
+            .value_or(EPMoves {});
     }
 
     template <Color Side, bool CapturesOnly>

--- a/libchess/include/libchess/notation/Algebraic.hpp
+++ b/libchess/include/libchess/notation/Algebraic.hpp
@@ -20,6 +20,7 @@
 
 #pragma once
 
+#include <expected>
 #include <libchess/moves/Move.hpp>
 #include <string>
 #include <string_view>
@@ -49,12 +50,11 @@ using moves::Move;
 
     This function expects Standard Algebraic Notation (SAN) strings.
 
-    @throws std::invalid_argument An exception will be thrown if a move cannot
-    be parsed correctly from the input string.
+    If the input string cannot be parsed correctly, returns an explanatory error string.
 
     @ingroup notation
     @see to_alg()
  */
-[[nodiscard]] Move from_alg(const Position& position, std::string_view text);
+[[nodiscard]] std::expected<Move, std::string> from_alg(const Position& position, std::string_view text);
 
 } // namespace chess::notation

--- a/libchess/include/libchess/notation/EPD.hpp
+++ b/libchess/include/libchess/notation/EPD.hpp
@@ -19,6 +19,7 @@
 
 #pragma once
 
+#include <expected>
 #include <libchess/game/Position.hpp>
 #include <string>
 #include <string_view>
@@ -51,14 +52,13 @@ struct EPDPosition final {
 
 /** Parses an EPD string.
 
-    @throws std::invalid_argument An exception will be thrown if the
-    EPD string cannot be parsed successfully.
+    If the input string cannot be parsed correctly, returns an explanatory error string.
 
     @ingroup notation
     @relates EPDPosition
     @see parse_all_epds()
  */
-[[nodiscard]] EPDPosition from_epd(std::string_view epdString);
+[[nodiscard]] std::expected<EPDPosition, string> from_epd(std::string_view epdString);
 
 /** Parses all EPDs in a string containing one EPD per line.
 

--- a/libchess/include/libchess/notation/FEN.hpp
+++ b/libchess/include/libchess/notation/FEN.hpp
@@ -27,6 +27,7 @@
 
 #pragma once
 
+#include <expected>
 #include <libchess/game/Position.hpp>
 #include <string>
 #include <string_view>
@@ -57,12 +58,11 @@ using game::Position;
 
 /** Returns a Position object encoding the given FEN string.
 
-    @throws std::invalid_argument An exception will be thrown if the
-    FEN string cannot be parsed correctly.
+    If the input string cannot be parsed correctly, returns an explanatory error string.
 
     @ingroup notation
     @see to_fen()
  */
-[[nodiscard]] Position from_fen(std::string_view fenString);
+[[nodiscard]] std::expected<Position, std::string> from_fen(std::string_view fenString);
 
 } // namespace chess::notation

--- a/libchess/include/libchess/notation/PGN.hpp
+++ b/libchess/include/libchess/notation/PGN.hpp
@@ -20,6 +20,7 @@
 #pragma once
 
 #include <cstdint>
+#include <expected>
 #include <libchess/game/Position.hpp>
 #include <libchess/game/Result.hpp>
 #include <libchess/moves/Move.hpp>
@@ -128,14 +129,13 @@ struct GameRecord final {
 
 /** Parses the text of a PGN file into a GameRecord object.
 
-    @throws std::invalid_argument An exception will be thrown
-    if the PGN can not be parsed correctly.
+    If the input string cannot be parsed correctly, returns an explanatory error string.
 
     @ingroup notation
     @relates GameRecord
     @see parse_all_pgns()
  */
-[[nodiscard]] GameRecord from_pgn(std::string_view pgnText);
+[[nodiscard]] std::expected<GameRecord, std::string_view> from_pgn(std::string_view pgnText);
 
 /** Parses a text file that may contain 0 or more PGNs into a list of
     GameRecord objects. PGNs in the ``fileContent`` should be separated

--- a/libchess/include/libchess/notation/UCI.hpp
+++ b/libchess/include/libchess/notation/UCI.hpp
@@ -21,6 +21,7 @@
 
 #pragma once
 
+#include <expected>
 #include <libchess/moves/Move.hpp>
 #include <string>
 #include <string_view>
@@ -44,13 +45,12 @@ using moves::Move;
 /** Parses the UCI-format algebraic notation string into a Move object.
     The current position is used to determine the type of the moved piece.
 
-    @throws std::invalid_argument An exception will be thrown if a move cannot
-    be parsed correctly from the input string.
+    If the input string cannot be parsed correctly, returns an explanatory error string.
 
     @ingroup notation
     @see from_uci()
  */
-[[nodiscard]] Move from_uci(
+[[nodiscard]] std::expected<Move, std::string> from_uci(
     const Position& position, std::string_view text);
 
 } // namespace chess::notation

--- a/libchess/include/libchess/pieces/PieceTypes.hpp
+++ b/libchess/include/libchess/pieces/PieceTypes.hpp
@@ -27,8 +27,10 @@
 
 #include <cstddef> // IWYU pragma: keep - for size_t
 #include <cstdint> // IWYU pragma: keep - for std::uint_fast8_t
+#include <expected>
 #include <format>
 #include <stdexcept>
+#include <string>
 #include <string_view>
 #include <utility>
 
@@ -57,12 +59,11 @@ enum class Type : std::uint_fast8_t {
     This function recognizes single-letter abbreviations (such as ``N`` for knight, etc.),
     or full piece names.
 
-    @throws std::invalid_argument An exception will be thrown if the input string cannot
-    be parsed correctly.
+    If the input string cannot be parsed correctly, returns an explanatory error string.
 
     @ingroup pieces
  */
-[[nodiscard, gnu::const]] constexpr Type from_string(std::string_view text);
+[[nodiscard]] std::expected<Type, std::string> from_string(std::string_view text);
 
 /** Converts the given piece type to its single-character representation.
 
@@ -126,7 +127,7 @@ constexpr char to_char(const Type type, const bool uppercase) noexcept
     return lowerChars[std::to_underlying(type)];
 }
 
-constexpr Type from_string(std::string_view text)
+inline std::expected<Type, std::string> from_string(std::string_view text)
 {
     if (text.length() != 1uz)
         text = text.substr(0uz, 1uz);
@@ -151,9 +152,10 @@ constexpr Type from_string(std::string_view text)
         case 'K': return Type::King;
 
         default:
-            throw std::invalid_argument {
-                std::format("Cannot parse piece type from invalid input string: {}", text)
-            };
+            return std::unexpected(
+                std::format(
+                    "Cannot parse piece type from invalid input string: {}",
+                    text));
     }
 }
 

--- a/libchess/include/libchess/uci/CommandParsing.hpp
+++ b/libchess/include/libchess/uci/CommandParsing.hpp
@@ -27,6 +27,7 @@
 
 #include <chrono>
 #include <cstddef> // IWYU pragma: keep - for size_t
+#include <expected>
 #include <libchess/game/Position.hpp>
 #include <libchess/moves/MoveGen.hpp>
 #include <optional>
@@ -47,9 +48,11 @@ using std::string_view;
 /** Parses the options following a UCI "position" command into a Position object.
     The ``options`` should not include the "position" token itself.
 
+    If the input string cannot be parsed correctly, returns an explanatory error string.
+
     @ingroup uci
  */
-[[nodiscard]] Position parse_position_options(string_view options);
+[[nodiscard]] std::expected<Position, std::string> parse_position_options(string_view options);
 
 /** This struct encapsulates the options to a UCI "register" command.
 

--- a/libchess/src/game/Position.cpp
+++ b/libchess/src/game/Position.cpp
@@ -184,8 +184,9 @@ void Position::flip()
 
     whiteCastlingRights = std::exchange(blackCastlingRights, whiteCastlingRights);
 
-    if (enPassantTargetSquare.has_value())
-        enPassantTargetSquare = square_vertical_flip(enPassantTargetSquare.value());
+    enPassantTargetSquare = enPassantTargetSquare.and_then([](const Square oldEPSquare) {
+        return std::optional { square_vertical_flip(oldEPSquare) };
+    });
 
     refresh_zobrist();
 }

--- a/libchess/src/notation/Algebraic.cpp
+++ b/libchess/src/notation/Algebraic.cpp
@@ -154,7 +154,7 @@ namespace {
     using board::Rank;
     using pieces::Color;
     using MoveSpan      = std::span<const Move>;
-    using SquareOrError = std::expected<Square, std::string>;
+    using SquareOrError = std::expected<Square, string>;
 
     [[nodiscard]] auto get_starting_square_from_file(
         const MoveSpan possibleOrigins, const File file)
@@ -380,7 +380,7 @@ namespace {
 
 } // namespace
 
-std::expected<Move, std::string> from_alg(const Position& position, string_view text)
+std::expected<Move, string> from_alg(const Position& position, string_view text)
 {
     text = util::trim(text);
 

--- a/libchess/src/notation/Algebraic.cpp
+++ b/libchess/src/notation/Algebraic.cpp
@@ -436,7 +436,7 @@ std::expected<Move, string> from_alg(const Position& position, string_view text)
             return *move;
 
     const auto pieceType = text.empty()
-                             ? PieceType::Pawn
+                             ? std::expected<PieceType, string> { PieceType::Pawn }
                              : pieces::from_string(text.substr(0uz, 1uz));
 
     if (not pieceType.has_value())

--- a/libchess/src/notation/Algebraic.cpp
+++ b/libchess/src/notation/Algebraic.cpp
@@ -360,6 +360,9 @@ namespace {
 
         const auto promotedType = pieces::from_string(text.substr(eqSgnPos + 1uz, 1uz));
 
+        if (not promotedType.has_value())
+            return std::nullopt;
+
         if (const auto xPos = text.find('x');
             xPos != string_view::npos) {
             // string is of form dxe8=Q
@@ -368,14 +371,14 @@ namespace {
                     .file = board::file_from_char(text.at(xPos - 1uz)),
                     .rank = color == Color::White ? Rank::Seven : Rank::Two },
                 Square::from_string(text.substr(eqSgnPos - 2uz, 2uz)),
-                PieceType::Pawn, promotedType
+                PieceType::Pawn, promotedType.value()
             };
         }
 
         // string is of form e8=Q
         return moves::promotion(
             board::file_from_char(text.front()),
-            color, promotedType);
+            color, promotedType.value());
     }
 
 } // namespace
@@ -427,13 +430,16 @@ std::expected<Move, string> from_alg(const Position& position, string_view text)
                              ? PieceType::Pawn
                              : pieces::from_string(text.substr(0uz, 1uz));
 
+    if (not pieceType.has_value())
+        return std::unexpected(pieceType.error());
+
     // trim piece type
     if (not text.empty())
         text = text.substr(1uz);
 
-    return get_starting_square(position, targetSquare, pieceType, text)
+    return get_starting_square(position, targetSquare, pieceType.value(), text)
         .transform([targetSquare, pieceType](const Square startSquare) {
-            return Move { startSquare, targetSquare, pieceType };
+            return Move { startSquare, targetSquare, pieceType.value() };
         });
 }
 

--- a/libchess/src/notation/Algebraic.cpp
+++ b/libchess/src/notation/Algebraic.cpp
@@ -371,11 +371,16 @@ namespace {
             if (not file.has_value())
                 return std::nullopt;
 
+            const auto destSquare = Square::from_string(text.substr(eqSgnPos - 2uz, 2uz));
+
+            if (not destSquare.has_value())
+                return std::nullopt;
+
             return Move {
                 Square {
                     .file = file.value(),
                     .rank = color == Color::White ? Rank::Seven : Rank::Two },
-                Square::from_string(text.substr(eqSgnPos - 2uz, 2uz)),
+                destSquare.value(),
                 PieceType::Pawn, promotedType.value()
             };
         }
@@ -414,6 +419,9 @@ std::expected<Move, string> from_alg(const Position& position, string_view text)
 
     const auto targetSquare = Square::from_string(text.substr(text.length() - 2uz));
 
+    if (not targetSquare.has_value())
+        return std::unexpected(targetSquare.error());
+
     // trim target square
     text.remove_suffix(2uz);
 
@@ -432,7 +440,7 @@ std::expected<Move, string> from_alg(const Position& position, string_view text)
     // pawn capture, it's the file letter of the starting square
 
     if (isCapture and not text.empty())
-        if (const auto move = parse_pawn_capture(targetSquare, text, position.sideToMove))
+        if (const auto move = parse_pawn_capture(targetSquare.value(), text, position.sideToMove))
             return *move;
 
     const auto pieceType = text.empty()
@@ -446,9 +454,9 @@ std::expected<Move, string> from_alg(const Position& position, string_view text)
     if (not text.empty())
         text = text.substr(1uz);
 
-    return get_starting_square(position, targetSquare, pieceType.value(), text)
+    return get_starting_square(position, targetSquare.value(), pieceType.value(), text)
         .transform([targetSquare, pieceType](const Square startSquare) {
-            return Move { startSquare, targetSquare, pieceType.value() };
+            return Move { startSquare, targetSquare.value(), pieceType.value() };
         });
 }
 

--- a/libchess/src/notation/Algebraic.cpp
+++ b/libchess/src/notation/Algebraic.cpp
@@ -397,7 +397,9 @@ namespace {
 
 } // namespace
 
-std::expected<Move, string> from_alg(const Position& position, string_view text)
+using MoveOrError = std::expected<Move, string>;
+
+MoveOrError from_alg(const Position& position, string_view text)
 {
     text = util::trim(text);
 
@@ -417,45 +419,43 @@ std::expected<Move, string> from_alg(const Position& position, string_view text)
     if (const auto move = parse_promotion(text, position.sideToMove))
         return *move;
 
-    const auto targetSquare = Square::from_string(text.substr(text.length() - 2uz));
+    return Square::from_string(text.substr(text.length() - 2uz))
+        .and_then([&text, &position](const Square targetSquare) -> MoveOrError {
+            // trim target square
+            text.remove_suffix(2uz);
 
-    if (not targetSquare.has_value())
-        return std::unexpected(targetSquare.error());
+            const bool isCapture = [text] {
+                if (text.empty())
+                    return false;
 
-    // trim target square
-    text.remove_suffix(2uz);
+                return text.back() == 'x';
+            }();
 
-    const bool isCapture = [text] {
-        if (text.empty())
-            return false;
+            if (isCapture)
+                text.remove_suffix(1uz);
 
-        return text.back() == 'x';
-    }();
+            // at this point, if text is empty, this an abbreviated pawn move such as "e4", etc.
+            // if text is not empty, the first char is either piece type, or in the case of a
+            // pawn capture, it's the file letter of the starting square
 
-    if (isCapture)
-        text.remove_suffix(1uz);
+            if (isCapture and not text.empty())
+                if (const auto move = parse_pawn_capture(targetSquare, text, position.sideToMove))
+                    return *move;
 
-    // at this point, if text is empty, this an abbreviated pawn move such as "e4", etc.
-    // if text is not empty, the first char is either piece type, or in the case of a
-    // pawn capture, it's the file letter of the starting square
+            const auto pieceType = text.empty()
+                                     ? std::expected<PieceType, string> { PieceType::Pawn }
+                                     : pieces::from_string(text.substr(0uz, 1uz));
 
-    if (isCapture and not text.empty())
-        if (const auto move = parse_pawn_capture(targetSquare.value(), text, position.sideToMove))
-            return *move;
+            return pieceType
+                .and_then([&text, &position, targetSquare](const PieceType type) {
+                    // trim piece type
+                    if (not text.empty())
+                        text = text.substr(1uz);
 
-    const auto pieceType = text.empty()
-                             ? std::expected<PieceType, string> { PieceType::Pawn }
-                             : pieces::from_string(text.substr(0uz, 1uz));
-
-    return pieceType
-        .and_then([&text, &position, dest = targetSquare.value()](const PieceType type) {
-            // trim piece type
-            if (not text.empty())
-                text = text.substr(1uz);
-
-            return get_starting_square(position, dest, type, text)
-                .transform([dest, type](const Square startSquare) {
-                    return Move { startSquare, dest, type };
+                    return get_starting_square(position, targetSquare, type, text)
+                        .transform([targetSquare, type](const Square startSquare) {
+                            return Move { startSquare, targetSquare, type };
+                        });
                 });
         });
 }

--- a/libchess/src/notation/Algebraic.cpp
+++ b/libchess/src/notation/Algebraic.cpp
@@ -447,16 +447,16 @@ std::expected<Move, string> from_alg(const Position& position, string_view text)
                              ? std::expected<PieceType, string> { PieceType::Pawn }
                              : pieces::from_string(text.substr(0uz, 1uz));
 
-    if (not pieceType.has_value())
-        return std::unexpected(pieceType.error());
+    return pieceType
+        .and_then([&text, &position, dest = targetSquare.value()](const PieceType type) {
+            // trim piece type
+            if (not text.empty())
+                text = text.substr(1uz);
 
-    // trim piece type
-    if (not text.empty())
-        text = text.substr(1uz);
-
-    return get_starting_square(position, targetSquare.value(), pieceType.value(), text)
-        .transform([targetSquare, pieceType](const Square startSquare) {
-            return Move { startSquare, targetSquare.value(), pieceType.value() };
+            return get_starting_square(position, dest, type, text)
+                .transform([dest, type](const Square startSquare) {
+                    return Move { startSquare, dest, type };
+                });
         });
 }
 

--- a/libchess/src/notation/Algebraic.cpp
+++ b/libchess/src/notation/Algebraic.cpp
@@ -366,9 +366,14 @@ namespace {
         if (const auto xPos = text.find('x');
             xPos != string_view::npos) {
             // string is of form dxe8=Q
+            const auto file = board::file_from_char(text.at(xPos - 1uz));
+
+            if (not file.has_value())
+                return std::nullopt;
+
             return Move {
                 Square {
-                    .file = board::file_from_char(text.at(xPos - 1uz)),
+                    .file = file.value(),
                     .rank = color == Color::White ? Rank::Seven : Rank::Two },
                 Square::from_string(text.substr(eqSgnPos - 2uz, 2uz)),
                 PieceType::Pawn, promotedType.value()
@@ -376,9 +381,13 @@ namespace {
         }
 
         // string is of form e8=Q
+        const auto file = board::file_from_char(text.front());
+
+        if (not file.has_value())
+            return std::nullopt;
+
         return moves::promotion(
-            board::file_from_char(text.front()),
-            color, promotedType.value());
+            file.value(), color, promotedType.value());
     }
 
 } // namespace

--- a/libchess/src/notation/Algebraic.cpp
+++ b/libchess/src/notation/Algebraic.cpp
@@ -14,6 +14,7 @@
 
 #include <algorithm>
 #include <cassert>
+#include <expected>
 #include <format>
 #include <iterator>
 #include <libchess/board/File.hpp>
@@ -28,7 +29,6 @@
 #include <libchess/util/Strings.hpp>
 #include <optional>
 #include <span>
-#include <stdexcept>
 #include <string>
 #include <string_view>
 #include <utility>
@@ -153,32 +153,31 @@ namespace {
     using board::File;
     using board::Rank;
     using pieces::Color;
-    using MoveSpan = std::span<const Move>;
+    using MoveSpan      = std::span<const Move>;
+    using SquareOrError = std::expected<Square, std::string>;
 
     [[nodiscard]] auto get_starting_square_from_file(
         const MoveSpan possibleOrigins, const File file)
-        -> Square
+        -> SquareOrError
     {
         auto moveStartsOnFile = [file](const Move& move) { return move.from().file == file; };
 
         if (std::cmp_greater(
                 std::ranges::count_if(possibleOrigins, moveStartsOnFile),
                 1)) {
-            throw std::invalid_argument {
+            return std::unexpected(
                 std::format(
                     "Disambiguation given file {}, but multiple pieces of this type can move to the target square from this file!",
-                    file)
-            };
+                    file));
         }
 
         const auto move = std::ranges::find_if(possibleOrigins, moveStartsOnFile);
 
         if (move == possibleOrigins.end()) {
-            throw std::invalid_argument {
+            return std::unexpected(
                 std::format(
                     "Disambiguation given file {}, but no piece of this type can move to the target square from this file!",
-                    file)
-            };
+                    file));
         }
 
         return move->from();
@@ -186,28 +185,26 @@ namespace {
 
     [[nodiscard]] auto get_starting_square_from_rank(
         const MoveSpan possibleOrigins, const Rank rank)
-        -> Square
+        -> SquareOrError
     {
         auto moveStartsOnRank = [rank](const Move& move) { return move.from().rank == rank; };
 
         if (std::cmp_greater(
                 std::ranges::count_if(possibleOrigins, moveStartsOnRank),
                 1)) {
-            throw std::invalid_argument {
+            return std::unexpected(
                 std::format(
                     "Disambiguation given rank {}, but multiple pieces of this type can move to the target square from this rank!",
-                    rank)
-            };
+                    rank));
         }
 
         const auto move = std::ranges::find_if(possibleOrigins, moveStartsOnRank);
 
         if (move == possibleOrigins.end()) {
-            throw std::invalid_argument {
+            return std::unexpected(
                 std::format(
                     "Disambiguation given rank {}, but no piece of this type can move to the target square from this rank!",
-                    rank)
-            };
+                    rank));
         }
 
         return move->from();
@@ -216,24 +213,25 @@ namespace {
     [[nodiscard]] auto get_starting_square(
         const Position& position, const Square& targetSquare, const PieceType piece,
         const string_view text)
-        -> Square
+        -> SquareOrError
     {
         const auto possibleOrigins = get_possible_move_origins(position, targetSquare, piece);
 
         if (possibleOrigins.empty()) {
-            throw std::invalid_argument {
-                std::format("No piece of type {} can legally reach square {}", piece, targetSquare)
-            };
+            return std::unexpected(
+                std::format(
+                    "No piece of type {} can legally reach square {}",
+                    piece, targetSquare));
         }
 
         if (possibleOrigins.size() == 1uz)
             return possibleOrigins.front().from();
 
         if (text.empty()) {
-            throw std::invalid_argument {
-                std::format("Multiple pieces of type {} can legally reach square {}, but no disambiguation string was provided",
-                    piece, targetSquare)
-            };
+            return std::unexpected(
+                std::format(
+                    "Multiple pieces of type {} can legally reach square {}, but no disambiguation string was provided",
+                    piece, targetSquare));
         }
 
         if (text.length() > 1uz)
@@ -281,10 +279,12 @@ namespace {
             case '7': return get_starting_square_from_rank(possibleOrigins, Rank::Seven);
             case '8': return get_starting_square_from_rank(possibleOrigins, Rank::Eight);
 
-            default:
-                throw std::invalid_argument {
-                    std::format("Unrecognized character in disambiguation string: {}", text.front())
-                };
+            default: {
+                return std::unexpected(
+                    std::format(
+                        "Unrecognized character in disambiguation string: {}",
+                        text.front()));
+            }
         }
     }
 
@@ -380,15 +380,12 @@ namespace {
 
 } // namespace
 
-Move from_alg(const Position& position, string_view text)
+std::expected<Move, std::string> from_alg(const Position& position, string_view text)
 {
     text = util::trim(text);
 
-    if (text.empty()) {
-        throw std::invalid_argument {
-            "Cannot parse Move from empty string"
-        };
-    }
+    if (text.empty())
+        return std::unexpected("Cannot parse Move from empty string");
 
     if (text.back() == '+' or text.back() == '#')
         text.remove_suffix(1uz);
@@ -434,10 +431,10 @@ Move from_alg(const Position& position, string_view text)
     if (not text.empty())
         text = text.substr(1uz);
 
-    return {
-        get_starting_square(position, targetSquare, pieceType, text),
-        targetSquare, pieceType
-    };
+    return get_starting_square(position, targetSquare, pieceType, text)
+        .transform([targetSquare, pieceType](const Square startSquare) {
+            return Move { startSquare, targetSquare, pieceType };
+        });
 }
 
 } // namespace chess::notation

--- a/libchess/src/notation/EPD.cpp
+++ b/libchess/src/notation/EPD.cpp
@@ -65,7 +65,9 @@ namespace {
 
 } // namespace
 
-std::expected<EPDPosition, string> from_epd(string_view epdString)
+using PositionOrError = std::expected<EPDPosition, string>;
+
+PositionOrError from_epd(string_view epdString)
 {
     using util::split_at_first_space;
 
@@ -81,31 +83,27 @@ std::expected<EPDPosition, string> from_epd(string_view epdString)
 
     const auto [piecePositions, rest1] = split_at_first_space(epdString);
 
-    const auto piecePosErr = fen_helpers::parse_piece_positions(piecePositions, pos.position);
+    return fen_helpers::parse_piece_positions(piecePositions, pos.position)
+        .and_then([rest1, &pos]() mutable -> PositionOrError {
+            const auto [sideToMove, rest2] = split_at_first_space(rest1);
 
-    if (not piecePosErr.has_value())
-        return std::unexpected(piecePosErr.error());
+            return fen_helpers::parse_side_to_move(sideToMove, pos.position)
+                .and_then([rest2, &pos]() mutable -> PositionOrError {
+                    const auto [castlingRights, rest3] = split_at_first_space(rest2);
 
-    const auto [sideToMove, rest2] = split_at_first_space(rest1);
+                    fen_helpers::parse_castling_rights(castlingRights, pos.position);
 
-    const auto stmErr = fen_helpers::parse_side_to_move(sideToMove, pos.position);
+                    const auto [epTarget, rest4] = split_at_first_space(rest3);
 
-    if (not stmErr.has_value())
-        return std::unexpected(stmErr.error());
+                    fen_helpers::parse_en_passant_target_square(epTarget, pos.position);
 
-    const auto [castlingRights, rest3] = split_at_first_space(rest2);
+                    parse_operations(pos, rest4);
 
-    fen_helpers::parse_castling_rights(castlingRights, pos.position);
+                    pos.position.refresh_zobrist();
 
-    const auto [epTarget, rest4] = split_at_first_space(rest3);
-
-    fen_helpers::parse_en_passant_target_square(epTarget, pos.position);
-
-    parse_operations(pos, rest4);
-
-    pos.position.refresh_zobrist();
-
-    return pos;
+                    return pos;
+                });
+        });
 }
 
 std::vector<EPDPosition> parse_all_epds(const string_view fileContent)

--- a/libchess/src/notation/EPD.cpp
+++ b/libchess/src/notation/EPD.cpp
@@ -14,11 +14,11 @@
 
 #include "FENHelpers.hpp"
 #include <cassert>
+#include <expected>
 #include <format>
 #include <libchess/notation/EPD.hpp>
 #include <libchess/util/Strings.hpp>
 #include <ranges>
-#include <stdexcept>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -65,17 +65,14 @@ namespace {
 
 } // namespace
 
-EPDPosition from_epd(string_view epdString)
+std::expected<EPDPosition, string> from_epd(string_view epdString)
 {
     using util::split_at_first_space;
 
     epdString = util::trim(epdString);
 
-    if (epdString.empty()) {
-        throw std::invalid_argument {
-            "Cannot parse Position from empty EPD string"
-        };
-    }
+    if (epdString.empty())
+        return std::unexpected("Cannot parse Position from empty EPD string");
 
     EPDPosition pos {
         .position   = Position::empty(),
@@ -84,11 +81,17 @@ EPDPosition from_epd(string_view epdString)
 
     const auto [piecePositions, rest1] = split_at_first_space(epdString);
 
-    fen_helpers::parse_piece_positions(piecePositions, pos.position);
+    const auto piecePosErr = fen_helpers::parse_piece_positions(piecePositions, pos.position);
+
+    if (not piecePosErr.has_value())
+        return std::unexpected(piecePosErr.error());
 
     const auto [sideToMove, rest2] = split_at_first_space(rest1);
 
-    fen_helpers::parse_side_to_move(sideToMove, pos.position);
+    const auto stmErr = fen_helpers::parse_side_to_move(sideToMove, pos.position);
+
+    if (not stmErr.has_value())
+        return std::unexpected(stmErr.error());
 
     const auto [castlingRights, rest3] = split_at_first_space(rest2);
 
@@ -107,10 +110,15 @@ EPDPosition from_epd(string_view epdString)
 
 std::vector<EPDPosition> parse_all_epds(const string_view fileContent)
 {
-    return util::lines_view(fileContent)
-         | std::views::filter([](const string_view line) { return not line.empty(); })
-         | std::views::transform([](const string_view line) { return from_epd(line); })
-         | std::ranges::to<std::vector>();
+    std::vector<EPDPosition> positions;
+
+    for (const auto str : util::lines_view(fileContent)
+                              | std::views::filter([](const string_view line) { return not line.empty(); })) {
+        if (auto pos = from_epd(str))
+            positions.emplace_back(pos.value());
+    }
+
+    return positions;
 }
 
 namespace {

--- a/libchess/src/notation/EPD.cpp
+++ b/libchess/src/notation/EPD.cpp
@@ -84,11 +84,11 @@ PositionOrError from_epd(string_view epdString)
     const auto [piecePositions, rest1] = split_at_first_space(epdString);
 
     return fen_helpers::parse_piece_positions(piecePositions, pos.position)
-        .and_then([rest1, &pos]() mutable -> PositionOrError {
+        .and_then([rest1, &pos]() -> PositionOrError {
             const auto [sideToMove, rest2] = split_at_first_space(rest1);
 
             return fen_helpers::parse_side_to_move(sideToMove, pos.position)
-                .and_then([rest2, &pos]() mutable -> PositionOrError {
+                .and_then([rest2, &pos]() -> PositionOrError {
                     const auto [castlingRights, rest3] = split_at_first_space(rest2);
 
                     fen_helpers::parse_castling_rights(castlingRights, pos.position);

--- a/libchess/src/notation/EPD.cpp
+++ b/libchess/src/notation/EPD.cpp
@@ -108,15 +108,12 @@ PositionOrError from_epd(string_view epdString)
 
 std::vector<EPDPosition> parse_all_epds(const string_view fileContent)
 {
-    std::vector<EPDPosition> positions;
-
-    for (const auto str : util::lines_view(fileContent)
-                              | std::views::filter([](const string_view line) { return not line.empty(); })) {
-        if (auto pos = from_epd(str))
-            positions.emplace_back(pos.value());
-    }
-
-    return positions;
+    return util::lines_view(fileContent)
+         | std::views::filter([](const string_view line) { return not line.empty(); })
+         | std::views::transform([](const string_view line) { return from_epd(line); })
+         | std::views::filter([](const PositionOrError& pos) { return pos.has_value(); })
+         | std::views::transform([](const PositionOrError& pos) { return pos.value(); })
+         | std::ranges::to<std::vector>();
 }
 
 namespace {

--- a/libchess/src/notation/FEN.cpp
+++ b/libchess/src/notation/FEN.cpp
@@ -88,11 +88,17 @@ Position from_fen(std::string_view fenString)
 
     const auto [piecePositions, rest1] = split_at_first_space(fenString);
 
-    fen_helpers::parse_piece_positions(piecePositions, position);
+    const auto piecePosErr = fen_helpers::parse_piece_positions(piecePositions, position);
+
+    if (not piecePosErr.has_value())
+        throw std::invalid_argument { piecePosErr.error() };
 
     const auto [sideToMove, rest2] = split_at_first_space(rest1);
 
-    fen_helpers::parse_side_to_move(sideToMove, position);
+    const auto stmErr = fen_helpers::parse_side_to_move(sideToMove, position);
+
+    if (not stmErr.has_value())
+        throw std::invalid_argument { stmErr.error() };
 
     const auto [castlingRights, rest3] = split_at_first_space(rest2);
 
@@ -102,6 +108,7 @@ Position from_fen(std::string_view fenString)
 
     fen_helpers::parse_en_passant_target_square(epTarget, position);
 
+    // TODO: allow these being omitted
     const auto [halfMoveClock, fullMoveCounter] = split_at_first_space(rest4);
 
     position.halfmoveClock   = int_from_string(halfMoveClock, position.halfmoveClock);

--- a/libchess/src/notation/FEN.cpp
+++ b/libchess/src/notation/FEN.cpp
@@ -101,11 +101,13 @@ PositionOrError from_fen(std::string_view fenString)
 
                     fen_helpers::parse_en_passant_target_square(epTarget, position);
 
-                    // TODO: allow these being omitted
-                    const auto [halfMoveClock, fullMoveCounter] = split_at_first_space(rest4);
+                    // tolerate the final 2 fields being omitted
+                    if (not util::trim(rest4).empty()) {
+                        const auto [halfMoveClock, fullMoveCounter] = split_at_first_space(rest4);
 
-                    position.halfmoveClock   = int_from_string(halfMoveClock, position.halfmoveClock);
-                    position.fullMoveCounter = int_from_string(fullMoveCounter, position.fullMoveCounter);
+                        position.halfmoveClock   = int_from_string(halfMoveClock, position.halfmoveClock);
+                        position.fullMoveCounter = int_from_string(fullMoveCounter, position.fullMoveCounter);
+                    }
 
                     position.refresh_zobrist();
 

--- a/libchess/src/notation/FEN.cpp
+++ b/libchess/src/notation/FEN.cpp
@@ -14,6 +14,7 @@
 
 #include "FENHelpers.hpp"
 #include <cstddef> // IWYU pragma: keep - for size_t
+#include <expected>
 #include <format>
 #include <iterator>
 #include <libchess/game/Position.hpp>
@@ -22,7 +23,6 @@
 #include <libchess/pieces/Colors.hpp>
 #include <libchess/util/Strings.hpp>
 #include <ranges>
-#include <stdexcept>
 #include <string>
 
 namespace chess::notation {
@@ -71,18 +71,15 @@ std::string to_fen(const Position& position, const bool alwaysWriteEPSqare)
     return fen;
 }
 
-Position from_fen(std::string_view fenString)
+std::expected<Position, std::string> from_fen(std::string_view fenString)
 {
     using util::int_from_string;
     using util::split_at_first_space;
 
     fenString = util::trim(fenString);
 
-    if (fenString.empty()) {
-        throw std::invalid_argument {
-            "Cannot parse Position from empty FEN string"
-        };
-    }
+    if (fenString.empty())
+        return std::unexpected("Cannot parse Position from empty FEN string");
 
     auto position = Position::empty();
 
@@ -91,14 +88,14 @@ Position from_fen(std::string_view fenString)
     const auto piecePosErr = fen_helpers::parse_piece_positions(piecePositions, position);
 
     if (not piecePosErr.has_value())
-        throw std::invalid_argument { piecePosErr.error() };
+        return std::unexpected(piecePosErr.error());
 
     const auto [sideToMove, rest2] = split_at_first_space(rest1);
 
     const auto stmErr = fen_helpers::parse_side_to_move(sideToMove, position);
 
     if (not stmErr.has_value())
-        throw std::invalid_argument { stmErr.error() };
+        return std::unexpected(stmErr.error());
 
     const auto [castlingRights, rest3] = split_at_first_space(rest2);
 

--- a/libchess/src/notation/FEN.cpp
+++ b/libchess/src/notation/FEN.cpp
@@ -71,7 +71,9 @@ std::string to_fen(const Position& position, const bool alwaysWriteEPSqare)
     return fen;
 }
 
-std::expected<Position, std::string> from_fen(std::string_view fenString)
+using PositionOrError = std::expected<Position, std::string>;
+
+PositionOrError from_fen(std::string_view fenString)
 {
     using util::int_from_string;
     using util::split_at_first_space;
@@ -85,35 +87,31 @@ std::expected<Position, std::string> from_fen(std::string_view fenString)
 
     const auto [piecePositions, rest1] = split_at_first_space(fenString);
 
-    const auto piecePosErr = fen_helpers::parse_piece_positions(piecePositions, position);
+    return fen_helpers::parse_piece_positions(piecePositions, position)
+        .and_then([rest1, &position]() mutable -> PositionOrError {
+            const auto [sideToMove, rest2] = split_at_first_space(rest1);
 
-    if (not piecePosErr.has_value())
-        return std::unexpected(piecePosErr.error());
+            return fen_helpers::parse_side_to_move(sideToMove, position)
+                .and_then([rest2, &position]() mutable -> PositionOrError {
+                    const auto [castlingRights, rest3] = split_at_first_space(rest2);
 
-    const auto [sideToMove, rest2] = split_at_first_space(rest1);
+                    fen_helpers::parse_castling_rights(castlingRights, position);
 
-    const auto stmErr = fen_helpers::parse_side_to_move(sideToMove, position);
+                    const auto [epTarget, rest4] = split_at_first_space(rest3);
 
-    if (not stmErr.has_value())
-        return std::unexpected(stmErr.error());
+                    fen_helpers::parse_en_passant_target_square(epTarget, position);
 
-    const auto [castlingRights, rest3] = split_at_first_space(rest2);
+                    // TODO: allow these being omitted
+                    const auto [halfMoveClock, fullMoveCounter] = split_at_first_space(rest4);
 
-    fen_helpers::parse_castling_rights(castlingRights, position);
+                    position.halfmoveClock   = int_from_string(halfMoveClock, position.halfmoveClock);
+                    position.fullMoveCounter = int_from_string(fullMoveCounter, position.fullMoveCounter);
 
-    const auto [epTarget, rest4] = split_at_first_space(rest3);
+                    position.refresh_zobrist();
 
-    fen_helpers::parse_en_passant_target_square(epTarget, position);
-
-    // TODO: allow these being omitted
-    const auto [halfMoveClock, fullMoveCounter] = split_at_first_space(rest4);
-
-    position.halfmoveClock   = int_from_string(halfMoveClock, position.halfmoveClock);
-    position.fullMoveCounter = int_from_string(fullMoveCounter, position.fullMoveCounter);
-
-    position.refresh_zobrist();
-
-    return position;
+                    return position;
+                });
+        });
 }
 
 } // namespace chess::notation

--- a/libchess/src/notation/FEN.cpp
+++ b/libchess/src/notation/FEN.cpp
@@ -88,11 +88,11 @@ PositionOrError from_fen(std::string_view fenString)
     const auto [piecePositions, rest1] = split_at_first_space(fenString);
 
     return fen_helpers::parse_piece_positions(piecePositions, position)
-        .and_then([rest1, &position]() mutable -> PositionOrError {
+        .and_then([rest1, &position]() -> PositionOrError {
             const auto [sideToMove, rest2] = split_at_first_space(rest1);
 
             return fen_helpers::parse_side_to_move(sideToMove, position)
-                .and_then([rest2, &position]() mutable -> PositionOrError {
+                .and_then([rest2, &position]() -> PositionOrError {
                     const auto [castlingRights, rest3] = split_at_first_space(rest2);
 
                     fen_helpers::parse_castling_rights(castlingRights, position);

--- a/libchess/src/notation/FENHelpers.cpp
+++ b/libchess/src/notation/FENHelpers.cpp
@@ -124,16 +124,20 @@ void write_en_passant_target_square(
     const std::optional<Square> targetSquare,
     string&                     output)
 {
-    if (not targetSquare.has_value()) {
-        [[likely]];
-        output.push_back('-');
-        return;
-    }
+    using Placeholder = std::optional<int>;
 
-    const auto [file, rank] = *targetSquare;
+    targetSquare
+        .and_then([&output](const Square epSquare) {
+            output.push_back(file_to_char(epSquare.file));
+            output.push_back(rank_to_char(epSquare.rank));
 
-    output.push_back(file_to_char(file));
-    output.push_back(rank_to_char(rank));
+            return Placeholder { 1 }; // return placeholder with value
+        })
+        .or_else([&output] {
+            output.push_back('-');
+
+            return Placeholder {};
+        });
 }
 
 namespace {

--- a/libchess/src/notation/FENHelpers.cpp
+++ b/libchess/src/notation/FENHelpers.cpp
@@ -262,7 +262,11 @@ void parse_en_passant_target_square(
         return;
     }
 
-    position.enPassantTargetSquare = Square::from_string(fenFragment);
+    Square::from_string(fenFragment)
+        .and_then([&position](const Square epSqare) {
+            position.enPassantTargetSquare = epSqare;
+            return std::expected<void, string> {};
+        });
 }
 
 } // namespace chess::notation::fen_helpers

--- a/libchess/src/notation/FENHelpers.cpp
+++ b/libchess/src/notation/FENHelpers.cpp
@@ -14,6 +14,7 @@
 
 #include "FENHelpers.hpp"
 #include <array>
+#include <expected>
 #include <format>
 #include <iterator>
 #include <libchess/board/Bitboard.hpp>
@@ -27,7 +28,6 @@
 #include <magic_enum/magic_enum.hpp>
 #include <optional>
 #include <ranges>
-#include <stdexcept>
 #include <string>
 #include <string_view>
 #include <utility>
@@ -141,7 +141,7 @@ namespace {
     // returns the rest of the piece positions fragment that was left after parsing this rank
     [[nodiscard]] auto parse_rank(
         const board::Rank rank, string_view fenFragment, Position& position)
-        -> string_view
+        -> std::expected<string_view, string>
     {
         const auto rankStart = Square { .file = board::File::A, .rank = rank }.index();
         const auto rankEnd   = rankStart + 8uz;
@@ -150,9 +150,7 @@ namespace {
 
         do {
             if (fenFragment.empty())
-                throw std::invalid_argument {
-                    "Unexpected end of piece positions FEN fragment"
-                };
+                return std::unexpected("Unexpected end of piece positions FEN fragment");
 
             switch (fenFragment.front()) {
                 case 'p': position.blackPieces.pawns.set(index); break;
@@ -184,9 +182,10 @@ namespace {
                     return fenFragment.substr(1uz);
 
                 default:
-                    throw std::invalid_argument {
-                        std::format("Unexpected char in piece positions FEN fragment: {}", fenFragment.front())
-                    };
+                    return std::unexpected(
+                        std::format(
+                            "Unexpected char in piece positions FEN fragment: {}",
+                            fenFragment.front()));
             }
 
             ++index;
@@ -201,27 +200,39 @@ namespace {
 
 } // namespace
 
-void parse_piece_positions(
+std::expected<void, string> parse_piece_positions(
     string_view fenFragment, Position& position)
 {
-    for (const auto rank : std::views::reverse(enum_values<board::Rank>()))
-        fenFragment = parse_rank(rank, fenFragment, position);
+    for (const auto rank : std::views::reverse(enum_values<board::Rank>())) {
+        const auto left = parse_rank(rank, fenFragment, position);
+
+        if (not left.has_value())
+            return std::unexpected(left.error());
+
+        fenFragment = left.value();
+    }
 
     position.whitePieces.refresh_occupied();
     position.blackPieces.refresh_occupied();
+
+    return {};
 }
 
-void parse_side_to_move(
+std::expected<void, string> parse_side_to_move(
     const string_view fenFragment, Position& position)
 {
-    if (fenFragment.length() != 1uz)
-        throw std::invalid_argument {
-            std::format("Expected single character for side to move, got: {}", fenFragment)
-        };
+    if (fenFragment.length() != 1uz) {
+        return std::unexpected(
+            std::format(
+                "Expected single character for side to move, got: {}",
+                fenFragment));
+    }
 
     const bool isBlack = fenFragment.front() == 'b';
 
     position.sideToMove = isBlack ? Color::Black : Color::White;
+
+    return {};
 }
 
 void parse_castling_rights(

--- a/libchess/src/notation/FENHelpers.hpp
+++ b/libchess/src/notation/FENHelpers.hpp
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <expected>
 #include <libchess/board/Square.hpp>
 #include <optional>
 #include <string>
@@ -46,10 +47,10 @@ void write_en_passant_target_square(
     std::optional<Square> targetSquare,
     string&               output);
 
-void parse_piece_positions(
+[[nodiscard]] std::expected<void, string> parse_piece_positions(
     string_view fenFragment, Position& position);
 
-void parse_side_to_move(
+[[nodiscard]] std::expected<void, string> parse_side_to_move(
     string_view fenFragment, Position& position);
 
 void parse_castling_rights(

--- a/libchess/src/notation/PGN.cpp
+++ b/libchess/src/notation/PGN.cpp
@@ -18,6 +18,7 @@
 #include <charconv>
 #include <cstddef> // IWYU pragma: keep - for size_t
 #include <cstdint> // IWYU pragma: keep - for std::uint_least8_t
+#include <expected>
 #include <format>
 #include <libchess/game/Result.hpp>
 #include <libchess/notation/Algebraic.hpp>
@@ -51,9 +52,10 @@ namespace {
     using std::size_t;
     using std::string;
     using std::string_view;
-    using Metadata   = std::unordered_map<std::string, std::string>;
-    using Moves      = std::vector<GameRecord::Move>;
-    using GameResult = std::optional<game::Result>;
+    using Metadata            = std::unordered_map<std::string, std::string>;
+    using Moves               = std::vector<GameRecord::Move>;
+    using GameResult          = std::optional<game::Result>;
+    using ResultStrOrErrorStr = std::expected<string_view, string_view>;
 
     using util::int_from_string;
     using util::split_at_first_space_or_newline;
@@ -62,16 +64,15 @@ namespace {
     // the rest of the PGN text that's left
     [[nodiscard]] auto parse_metadata_tags(
         string_view pgnText, Metadata& metadata)
-        -> string_view
+        -> ResultStrOrErrorStr
     {
         auto openingBracketIdx = pgnText.find('[');
 
         while (openingBracketIdx != string_view::npos) {
             const auto closingBracketIdx = pgnText.find(']', openingBracketIdx + 1uz);
 
-            if (closingBracketIdx == string_view::npos) {
-                throw std::invalid_argument { "Invalid PGN: expected ']' following '['" };
-            }
+            if (closingBracketIdx == string_view::npos)
+                return std::unexpected("Invalid PGN: expected ']' following '['");
 
             assert(closingBracketIdx > openingBracketIdx);
 
@@ -107,15 +108,14 @@ namespace {
     // and returns the rest of the pgnText after the } that closes this comment
     [[nodiscard]] auto parse_block_comment(
         const string_view pgnText, Moves& output)
-        -> string_view
+        -> ResultStrOrErrorStr
     {
         assert(pgnText.front() == '{');
 
         const auto closeBracketIdx = pgnText.find('}');
 
-        if (closeBracketIdx == string_view::npos) {
-            throw std::invalid_argument { "Expected '}' following '{'" };
-        }
+        if (closeBracketIdx == string_view::npos)
+            return std::unexpected("Expected '}' following '{'");
 
         if (not output.empty())
             output.back().comment = pgnText.substr(1uz, closeBracketIdx - 1uz);
@@ -187,8 +187,9 @@ namespace {
         output.emplace_back(move);
     }
 
-    string_view parse_variation(
-        string_view pgnText, const Position& position, Moves& output);
+    auto parse_variation(
+        string_view pgnText, const Position& position, Moves& output)
+        -> ResultStrOrErrorStr;
 
     // parses a move list, including nested comments, NAGs, and variations
     // if IsVariation is true, always returns an empty string_view
@@ -198,7 +199,7 @@ namespace {
         string_view pgnText,
         Position    position, // intentionally by copy!
         Moves&      output)
-        -> string_view
+        -> ResultStrOrErrorStr
     {
         // With a PGN like: 1. e4 (e3), the move e3 was made from the starting position,
         // not the position after e4. So because Position doesn't have an unmake_move()
@@ -214,7 +215,12 @@ namespace {
             switch (pgnText.front()) {
                 case '{': {
                     // comment: { continues to }
-                    pgnText = parse_block_comment(pgnText, output);
+                    const auto rest = parse_block_comment(pgnText, output);
+
+                    if (not rest.has_value())
+                        return std::unexpected(rest.error());
+
+                    pgnText = rest.value();
                     continue;
                 }
 
@@ -232,7 +238,12 @@ namespace {
 
                 case '(': {
                     // variation
-                    pgnText = parse_variation(pgnText, lastPos, output);
+                    const auto rest = parse_variation(pgnText, lastPos, output);
+
+                    if (not rest.has_value())
+                        return std::unexpected(rest.error());
+
+                    pgnText = rest.value();
                     continue;
                 }
 
@@ -272,23 +283,23 @@ namespace {
         const string_view pgnText,
         const Position&   position,
         Moves&            output)
-        -> string_view
+        -> ResultStrOrErrorStr
     {
         assert(pgnText.front() == '(');
 
-        if (output.empty()) {
-            throw std::invalid_argument { "Cannot parse a variation with an empty move list!" };
-        }
+        if (output.empty())
+            return std::unexpected("Cannot parse a variation with an empty move list!");
 
         const auto closeParenIdx = util::find_matching_close_paren(pgnText);
 
         auto& variation = output.back().variations.emplace_back();
 
-        parse_moves_internal<true>(
+        return parse_moves_internal<true>(
             pgnText.substr(1uz, closeParenIdx - 1uz),
-            position, variation);
-
-        return pgnText.substr(closeParenIdx + 1uz);
+            position, variation)
+            .and_then([pgnText, closeParenIdx]([[maybe_unused]] const string_view alwaysEmpty) -> ResultStrOrErrorStr {
+                return pgnText.substr(closeParenIdx + 1uz);
+            });
     }
 
     // writes the parsed moves into output and returns the
@@ -297,10 +308,9 @@ namespace {
         const string_view pgnText,
         const Position&   position,
         Moves&            output)
-        -> string_view
+        -> std::expected<string_view, string_view>
     {
-        return parse_moves_internal<false>(
-            pgnText, position, output);
+        return parse_moves_internal<false>(pgnText, position, output);
     }
 
     [[nodiscard]] auto parse_game_result(
@@ -331,18 +341,25 @@ GameRecord from_pgn(string_view pgnText)
 {
     GameRecord game;
 
-    pgnText = parse_metadata_tags(pgnText, game.metadata);
+    const auto afterMeta = parse_metadata_tags(pgnText, game.metadata);
+
+    if (not afterMeta.has_value())
+        throw std::invalid_argument { std::string { afterMeta.error() } };
+
+    pgnText = afterMeta.value();
 
     if (const auto posStr = game.metadata.find("FEN");
         posStr != game.metadata.end()) {
-        if (const auto pos = from_fen(posStr->second))
-            game.startingPosition = pos.value();
+        game.startingPosition = from_fen(posStr->second).value_or(Position {});
     }
 
     const auto resultText = parse_move_list(
         pgnText, game.startingPosition, game.moves);
 
-    game.result = parse_game_result(resultText, game);
+    if (not resultText.has_value())
+        throw std::invalid_argument { std::string { resultText.error() } };
+
+    game.result = parse_game_result(resultText.value(), game);
 
     return game;
 }

--- a/libchess/src/notation/PGN.cpp
+++ b/libchess/src/notation/PGN.cpp
@@ -28,7 +28,6 @@
 #include <numeric>
 #include <optional>
 #include <ranges>
-#include <stdexcept>
 #include <string>
 #include <string_view>
 #include <unordered_map>

--- a/libchess/src/notation/PGN.cpp
+++ b/libchess/src/notation/PGN.cpp
@@ -542,24 +542,25 @@ namespace {
     void write_game_result(
         const GameResult result, string& output)
     {
-        if (not result.has_value())
-            return;
+        result.and_then([&output](const game::Result outcome) {
+            switch (outcome) {
+                case game::Result::Draw:
+                    output.append("1/2-1/2");
+                    break;
 
-        switch (*result) {
-            case game::Result::Draw:
-                output.append("1/2-1/2");
-                return;
+                case game::Result::WhiteWon:
+                    output.append("1-0");
+                    break;
 
-            case game::Result::WhiteWon:
-                output.append("1-0");
-                return;
+                case game::Result::BlackWon:
+                    output.append("0-1");
+                    break;
 
-            case game::Result::BlackWon:
-                output.append("0-1");
-                return;
+                default: std::unreachable();
+            }
 
-            default: std::unreachable();
-        }
+            return std::optional<int> {};
+        });
     }
 
 } // namespace

--- a/libchess/src/notation/PGN.cpp
+++ b/libchess/src/notation/PGN.cpp
@@ -180,7 +180,7 @@ namespace {
             moveText = moveText.substr(lastDotIdx + 1uz);
         }
 
-        const auto move = from_alg(position, moveText);
+        const auto move = from_alg(position, moveText).value();
 
         position.make_move(move);
 

--- a/libchess/src/notation/PGN.cpp
+++ b/libchess/src/notation/PGN.cpp
@@ -333,9 +333,10 @@ GameRecord from_pgn(string_view pgnText)
 
     pgnText = parse_metadata_tags(pgnText, game.metadata);
 
-    if (const auto pos = game.metadata.find("FEN");
-        pos != game.metadata.end()) {
-        game.startingPosition = from_fen(pos->second);
+    if (const auto posStr = game.metadata.find("FEN");
+        posStr != game.metadata.end()) {
+        if (const auto pos = from_fen(posStr->second))
+            game.startingPosition = pos.value();
     }
 
     const auto resultText = parse_move_list(

--- a/libchess/src/notation/PGN.cpp
+++ b/libchess/src/notation/PGN.cpp
@@ -308,7 +308,7 @@ namespace {
         const string_view pgnText,
         const Position&   position,
         Moves&            output)
-        -> std::expected<string_view, string_view>
+        -> ResultStrOrErrorStr
     {
         return parse_moves_internal<false>(pgnText, position, output);
     }
@@ -337,31 +337,27 @@ namespace {
 
 } // namespace
 
-GameRecord from_pgn(string_view pgnText)
+using GameOrError = std::expected<GameRecord, string_view>;
+
+GameOrError from_pgn(const string_view pgnText)
 {
     GameRecord game;
 
-    const auto afterMeta = parse_metadata_tags(pgnText, game.metadata);
+    return parse_metadata_tags(pgnText, game.metadata)
+        .and_then([&game](const string_view afterMeta) -> GameOrError {
+            if (const auto posStr = game.metadata.find("FEN");
+                posStr != game.metadata.end()) {
+                game.startingPosition = from_fen(posStr->second).value_or(Position {});
+            }
 
-    if (not afterMeta.has_value())
-        throw std::invalid_argument { std::string { afterMeta.error() } };
+            return parse_move_list(
+                afterMeta, game.startingPosition, game.moves)
+                .and_then([&game](const string_view resultText) -> GameOrError {
+                    game.result = parse_game_result(resultText, game);
 
-    pgnText = afterMeta.value();
-
-    if (const auto posStr = game.metadata.find("FEN");
-        posStr != game.metadata.end()) {
-        game.startingPosition = from_fen(posStr->second).value_or(Position {});
-    }
-
-    const auto resultText = parse_move_list(
-        pgnText, game.startingPosition, game.moves);
-
-    if (not resultText.has_value())
-        throw std::invalid_argument { std::string { resultText.error() } };
-
-    game.result = parse_game_result(resultText.value(), game);
-
-    return game;
+                    return game;
+                });
+        });
 }
 
 namespace {
@@ -413,14 +409,18 @@ std::vector<GameRecord> parse_all_pgns(string_view fileContent)
         const auto moveTextToNextPGN = find_next_line<true>(fileContent.substr(moveTextStart + 1uz));
 
         if (moveTextToNextPGN == string_view::npos) {
-            games.emplace_back(from_pgn(fileContent));
+            if (const auto game = from_pgn(fileContent))
+                games.emplace_back(game.value());
+
             return games;
         }
 
         const auto nextPGNStart = moveTextStart + moveTextToNextPGN;
 
-        games.emplace_back(from_pgn(
-            fileContent.substr(0uz, nextPGNStart)));
+        if (const auto game = from_pgn(
+                fileContent.substr(0uz, nextPGNStart))) {
+            games.emplace_back(game.value());
+        }
 
         fileContent.remove_prefix(nextPGNStart);
         fileContent = util::trim(fileContent);

--- a/libchess/src/notation/PGN.cpp
+++ b/libchess/src/notation/PGN.cpp
@@ -349,8 +349,7 @@ GameOrError from_pgn(const string_view pgnText)
                 game.startingPosition = from_fen(posStr->second).value_or(Position {});
             }
 
-            return parse_move_list(
-                afterMeta, game.startingPosition, game.moves)
+            return parse_move_list(afterMeta, game.startingPosition, game.moves)
                 .and_then([&game](const string_view resultText) -> GameOrError {
                     game.result = parse_game_result(resultText, game);
 

--- a/libchess/src/notation/UCI.cpp
+++ b/libchess/src/notation/UCI.cpp
@@ -12,6 +12,7 @@
  * ======================================================================================
  */
 
+#include <expected>
 #include <format>
 #include <libchess/board/Square.hpp>
 #include <libchess/game/Position.hpp>
@@ -20,7 +21,6 @@
 #include <libchess/pieces/PieceTypes.hpp>
 #include <libchess/util/Strings.hpp>
 #include <magic_enum/magic_enum.hpp>
-#include <stdexcept>
 #include <string>
 #include <string_view>
 
@@ -43,52 +43,52 @@ std::string to_uci(const Move& move)
     return std::format("{}{}", move.from(), move.to());
 }
 
-Move from_uci(const Position& position, std::string_view text)
+std::expected<Move, std::string> from_uci(
+    const Position& position, std::string_view text)
 {
     using board::Square;
 
     text = util::trim(text);
 
     if (text.empty()) {
-        throw std::invalid_argument {
-            "Cannot parse Move from empty string"
-        };
+        [[unlikely]];
+        return std::unexpected("Cannot parse Move from empty string");
     }
 
     if (text == "0000") {
         [[unlikely]];
-        return {};
+        return Move {};
     }
 
     const auto from = Square::from_string(text.substr(0uz, 2uz));
-    text            = text.substr(2uz);
+
+    text = text.substr(2uz);
 
     const auto dest = Square::from_string(text.substr(0uz, 2uz));
-    text            = text.substr(2uz);
+
+    text = text.substr(2uz);
 
     const auto& pieces = position.our_pieces();
 
     const auto movedType = pieces.get_piece_on(from);
 
     if (not movedType.has_value()) {
-        throw std::invalid_argument {
+        [[unlikely]];
+        return std::unexpected(
             std::format(
                 "No piece for color {} can move from square {}",
-                magic_enum::enum_name(position.sideToMove), from)
-        };
+                magic_enum::enum_name(position.sideToMove), from));
     }
 
     // promotion
     if (not text.empty()) {
         [[unlikely]];
-        return {
+        return Move {
             from, dest, movedType.value(), pieces::from_string(text)
         };
     }
 
-    return {
-        from, dest, movedType.value()
-    };
+    return Move { from, dest, movedType.value() };
 }
 
 } // namespace chess::notation

--- a/libchess/src/notation/UCI.cpp
+++ b/libchess/src/notation/UCI.cpp
@@ -43,7 +43,9 @@ std::string to_uci(const Move& move)
     return std::format("{}{}", move.from(), move.to());
 }
 
-std::expected<Move, std::string> from_uci(
+using MoveOrError = std::expected<Move, std::string>;
+
+MoveOrError from_uci(
     const Position& position, std::string_view text)
 {
     using board::Square;
@@ -67,43 +69,37 @@ std::expected<Move, std::string> from_uci(
 
     text = text.substr(2uz);
 
-    const auto dest = Square::from_string(text.substr(0uz, 2uz));
+    return Square::from_string(text.substr(0uz, 2uz))
+        .and_then([&text, &position, start = from.value()](const Square dest) -> MoveOrError {
+            text                 = text.substr(2uz);
+            const auto movedType = position.our_pieces().get_piece_on(start);
 
-    if (not dest.has_value())
-        return std::unexpected(dest.error());
+            if (not movedType.has_value()) {
+                [[unlikely]];
+                return std::unexpected(
+                    std::format(
+                        "No piece for color {} can move from square {}",
+                        magic_enum::enum_name(position.sideToMove), start));
+            }
 
-    text = text.substr(2uz);
+            // promotion
+            if (not text.empty()) {
+                [[unlikely]];
 
-    const auto& pieces = position.our_pieces();
+                return pieces::from_string(text)
+                    .transform([start, dest, type = movedType.value()](const pieces::Type promotedType) {
+                        return Move { start, dest, type, promotedType };
+                    })
+                    .or_else([](const std::string_view parseError) -> MoveOrError {
+                        return std::unexpected(
+                            std::format(
+                                "Error parsing promoted type: {}",
+                                parseError));
+                    });
+            }
 
-    const auto movedType = pieces.get_piece_on(from.value());
-
-    if (not movedType.has_value()) {
-        [[unlikely]];
-        return std::unexpected(
-            std::format(
-                "No piece for color {} can move from square {}",
-                magic_enum::enum_name(position.sideToMove), from.value()));
-    }
-
-    // promotion
-    if (not text.empty()) {
-        [[unlikely]];
-
-        const auto promotionType = pieces::from_string(text);
-
-        if (not promotionType.has_value()) {
-            return std::unexpected(
-                std::format("Error parsing promoted type: {}",
-                    promotionType.error()));
-        }
-
-        return Move {
-            from.value(), dest.value(), movedType.value(), promotionType.value()
-        };
-    }
-
-    return Move { from.value(), dest.value(), movedType.value() };
+            return Move { start, dest, movedType.value() };
+        });
 }
 
 } // namespace chess::notation

--- a/libchess/src/notation/UCI.cpp
+++ b/libchess/src/notation/UCI.cpp
@@ -83,8 +83,17 @@ std::expected<Move, std::string> from_uci(
     // promotion
     if (not text.empty()) {
         [[unlikely]];
+
+        const auto promotionType = pieces::from_string(text);
+
+        if (not promotionType.has_value()) {
+            return std::unexpected(
+                std::format("Error parsing promoted type: {}",
+                    promotionType.error()));
+        }
+
         return Move {
-            from, dest, movedType.value(), pieces::from_string(text)
+            from, dest, movedType.value(), promotionType.value()
         };
     }
 

--- a/libchess/src/notation/UCI.cpp
+++ b/libchess/src/notation/UCI.cpp
@@ -62,43 +62,42 @@ MoveOrError from_uci(
         return Move {};
     }
 
-    const auto from = Square::from_string(text.substr(0uz, 2uz));
-
-    if (not from.has_value())
-        return std::unexpected(from.error());
-
-    text = text.substr(2uz);
-
     return Square::from_string(text.substr(0uz, 2uz))
-        .and_then([&text, &position, start = from.value()](const Square dest) -> MoveOrError {
-            text                 = text.substr(2uz);
-            const auto movedType = position.our_pieces().get_piece_on(start);
+        .and_then([&text, &position](const Square from) {
+            text = text.substr(2uz);
 
-            if (not movedType.has_value()) {
-                [[unlikely]];
-                return std::unexpected(
-                    std::format(
-                        "No piece for color {} can move from square {}",
-                        magic_enum::enum_name(position.sideToMove), start));
-            }
+            return Square::from_string(text.substr(0uz, 2uz))
+                .and_then([&text, &position, from](const Square dest) -> MoveOrError {
+                    text = text.substr(2uz);
 
-            // promotion
-            if (not text.empty()) {
-                [[unlikely]];
+                    const auto movedType = position.our_pieces().get_piece_on(from);
 
-                return pieces::from_string(text)
-                    .transform([start, dest, type = movedType.value()](const pieces::Type promotedType) {
-                        return Move { start, dest, type, promotedType };
-                    })
-                    .or_else([](const std::string_view parseError) -> MoveOrError {
+                    if (not movedType.has_value()) {
+                        [[unlikely]];
                         return std::unexpected(
                             std::format(
-                                "Error parsing promoted type: {}",
-                                parseError));
-                    });
-            }
+                                "No piece for color {} can move from square {}",
+                                magic_enum::enum_name(position.sideToMove), from));
+                    }
 
-            return Move { start, dest, movedType.value() };
+                    // promotion
+                    if (not text.empty()) {
+                        [[unlikely]];
+
+                        return pieces::from_string(text)
+                            .transform([from, dest, type = movedType.value()](const pieces::Type promotedType) {
+                                return Move { from, dest, type, promotedType };
+                            })
+                            .or_else([](const std::string_view parseError) -> MoveOrError {
+                                return std::unexpected(
+                                    std::format(
+                                        "Error parsing promoted type: {}",
+                                        parseError));
+                            });
+                    }
+
+                    return Move { from, dest, movedType.value() };
+                });
         });
 }
 

--- a/libchess/src/notation/UCI.cpp
+++ b/libchess/src/notation/UCI.cpp
@@ -62,22 +62,28 @@ std::expected<Move, std::string> from_uci(
 
     const auto from = Square::from_string(text.substr(0uz, 2uz));
 
+    if (not from.has_value())
+        return std::unexpected(from.error());
+
     text = text.substr(2uz);
 
     const auto dest = Square::from_string(text.substr(0uz, 2uz));
+
+    if (not dest.has_value())
+        return std::unexpected(dest.error());
 
     text = text.substr(2uz);
 
     const auto& pieces = position.our_pieces();
 
-    const auto movedType = pieces.get_piece_on(from);
+    const auto movedType = pieces.get_piece_on(from.value());
 
     if (not movedType.has_value()) {
         [[unlikely]];
         return std::unexpected(
             std::format(
                 "No piece for color {} can move from square {}",
-                magic_enum::enum_name(position.sideToMove), from));
+                magic_enum::enum_name(position.sideToMove), from.value()));
     }
 
     // promotion
@@ -93,11 +99,11 @@ std::expected<Move, std::string> from_uci(
         }
 
         return Move {
-            from, dest, movedType.value(), promotionType.value()
+            from.value(), dest.value(), movedType.value(), promotionType.value()
         };
     }
 
-    return Move { from, dest, movedType.value() };
+    return Move { from.value(), dest.value(), movedType.value() };
 }
 
 } // namespace chess::notation

--- a/libchess/src/uci/CommandParsing.cpp
+++ b/libchess/src/uci/CommandParsing.cpp
@@ -92,8 +92,12 @@ Position parse_position_options(string_view options)
     while (not moves.empty()) {
         const auto [firstMove, rest2] = split_at_first_space(moves);
 
-        position.make_move(
-            notation::from_uci(position, firstMove));
+        const auto move = notation::from_uci(position, firstMove);
+
+        if (not move.has_value())
+            throw std::invalid_argument { move.error() };
+
+        position.make_move(move.value());
 
         moves = trim(rest2);
     }
@@ -211,7 +215,8 @@ namespace {
 
             options = trim(rest);
 
-            *outputIt = notation::from_uci(currentPosition, firstMove);
+            if (const auto move = notation::from_uci(currentPosition, firstMove))
+                *outputIt = move.value();
         }
 
         return options; // NOLINT

--- a/libchess/src/uci/CommandParsing.cpp
+++ b/libchess/src/uci/CommandParsing.cpp
@@ -93,12 +93,17 @@ std::expected<Position, std::string> parse_position_options(string_view options)
     while (not moves.empty()) {
         const auto [firstMove, rest2] = split_at_first_space(moves);
 
-        const auto move = notation::from_uci(position, firstMove);
+        const auto parsed = notation::from_uci(position, firstMove);
 
-        if (not move.has_value())
-            return std::unexpected(move.error());
+        if (not parsed.has_value())
+            return std::unexpected(parsed.error());
 
-        position.make_move(move.value());
+        const auto move = parsed.value();
+
+        if (move.is_null())
+            return std::unexpected("Found null move in move list");
+
+        position.make_move(move);
 
         moves = trim(rest2);
     }

--- a/libchess/src/uci/CommandParsing.cpp
+++ b/libchess/src/uci/CommandParsing.cpp
@@ -15,6 +15,7 @@
 #include <algorithm>
 #include <array>
 #include <chrono>
+#include <expected>
 #include <iterator>
 #include <libchess/moves/Move.hpp>
 #include <libchess/notation/FEN.hpp>
@@ -40,7 +41,7 @@ using util::trim;
 // split_at_first_space() will return a pair whose first element is empty
 // if its input string began with a space!
 
-Position parse_position_options(string_view options)
+std::expected<Position, std::string> parse_position_options(string_view options)
 {
     // position [fen <fenstring> | startpos ]  moves <move1> .... <movei>
     // options doesn't include the "position" token itself
@@ -65,7 +66,7 @@ Position parse_position_options(string_view options)
         const auto fenPos = notation::from_fen(fenString);
 
         if (not fenPos.has_value())
-            throw std::invalid_argument { fenPos.error() };
+            return std::unexpected(fenPos.error());
 
         position = fenPos.value();
 
@@ -95,7 +96,7 @@ Position parse_position_options(string_view options)
         const auto move = notation::from_uci(position, firstMove);
 
         if (not move.has_value())
-            throw std::invalid_argument { move.error() };
+            return std::unexpected(move.error());
 
         position.make_move(move.value());
 

--- a/libchess/src/uci/CommandParsing.cpp
+++ b/libchess/src/uci/CommandParsing.cpp
@@ -22,6 +22,7 @@
 #include <libchess/uci/CommandParsing.hpp>
 #include <libchess/util/Strings.hpp>
 #include <optional>
+#include <stdexcept>
 #include <string>
 #include <string_view>
 #include <utility>
@@ -61,7 +62,12 @@ Position parse_position_options(string_view options)
 
         const auto fenString = isNPos ? rest : rest.substr(0uz, movesTokenIdx);
 
-        position = notation::from_fen(fenString);
+        const auto fenPos = notation::from_fen(fenString);
+
+        if (not fenPos.has_value())
+            throw std::invalid_argument { fenPos.error() };
+
+        position = fenPos.value();
 
         if (isNPos) {
             // the "moves" token wasn't found, so assume that the FEN string

--- a/libchess/src/uci/EngineBase.cpp
+++ b/libchess/src/uci/EngineBase.cpp
@@ -135,13 +135,14 @@ void EngineBase::handle_setpos(const string_view arguments)
     // we print an error message via `info string` and keep the old position.
     // See this Stockfish PR discussion: https://github.com/official-stockfish/Stockfish/pull/4563
 
+    using MaybeError = std::expected<void, std::string>;
+
     parse_position_options(arguments)
-        .and_then([this](const Position& pos) -> std::expected<void, std::string> {
+        .and_then([this](const Position& pos) -> MaybeError {
             if (const auto errorStr = pos.is_illegal()) {
                 [[unlikely]];
-                info_string(std::format("Attempted to set illegal position: {}", errorStr.value()));
-                info_string(std::format("Retained previous position: {}", notation::to_fen(position)));
-                return {};
+                return std::unexpected(
+                    std::format("Position is illegal: {}", errorStr.value()));
             }
 
             position = pos;
@@ -150,7 +151,7 @@ void EngineBase::handle_setpos(const string_view arguments)
 
             return {};
         })
-        .or_else([this](const std::string_view error) -> std::expected<void, std::string> {
+        .or_else([this](const std::string_view error) -> MaybeError {
             info_string(std::format("Error setting position: {}", error));
             info_string(std::format("Retained previous position: {}", notation::to_fen(position)));
 

--- a/libchess/src/uci/EngineBase.cpp
+++ b/libchess/src/uci/EngineBase.cpp
@@ -13,7 +13,7 @@
  */
 
 #include <algorithm>
-#include <exception>
+#include <expected>
 #include <format>
 #include <iostream>
 #include <libchess/notation/FEN.hpp>
@@ -23,6 +23,7 @@
 #include <libchess/util/Strings.hpp>
 #include <print>
 #include <string>
+#include <string_view>
 
 namespace chess::uci {
 
@@ -124,32 +125,37 @@ void EngineBase::respond_to_uci()
     println("uciok");
 }
 
-// According to the UCI spec, engines should ignore invalid commands.
-// If the FEN or movelist sent is invalid, an exception will be thrown
-// when trying to parse it, which we could simply not catch here to let
-// the engine terminate; however, it seems to be the most spec-compliant
-// behavior to ignore the invalid command and not terminate the engine.
-// If a parsing error is thrown, or if the new position is determined
-// to be illegal, we print an error message via `info string` and keep
-// the old position. See this Stockfish PR discussion:
-// https://github.com/official-stockfish/Stockfish/pull/4563
 void EngineBase::handle_setpos(const string_view arguments)
-try {
-    const auto newPos = parse_position_options(arguments);
+{
+    // According to the UCI spec, engines should ignore invalid commands.
+    // If the FEN or movelist sent is invalid, we could terminate the engine
+    // with an error exit code; however, it seems to be the most spec-compliant
+    // behavior to ignore the invalid command and not terminate the engine.
+    // If parsing returns an error, or if the new position seems to be illegal,
+    // we print an error message via `info string` and keep the old position.
+    // See this Stockfish PR discussion: https://github.com/official-stockfish/Stockfish/pull/4563
 
-    if (const auto errorStr = newPos.is_illegal()) {
-        [[unlikely]];
-        info_string(std::format("Attempted to set illegal position: {}", errorStr.value()));
-        info_string(std::format("Retained previous position: {}", notation::to_fen(position)));
-        return;
-    }
+    parse_position_options(arguments)
+        .and_then([this](const Position& pos) -> std::expected<void, std::string> {
+            if (const auto errorStr = pos.is_illegal()) {
+                [[unlikely]];
+                info_string(std::format("Attempted to set illegal position: {}", errorStr.value()));
+                info_string(std::format("Retained previous position: {}", notation::to_fen(position)));
+                return {};
+            }
 
-    position = newPos;
+            position = pos;
 
-    set_position(newPos);
-} catch (const std::exception& exception) {
-    info_string(std::format("Error setting position: {}", exception.what()));
-    info_string(std::format("Retained previous position: {}", notation::to_fen(position)));
+            set_position(pos);
+
+            return {};
+        })
+        .or_else([this](const std::string_view error) -> std::expected<void, std::string> {
+            info_string(std::format("Error setting position: {}", error));
+            info_string(std::format("Retained previous position: {}", notation::to_fen(position)));
+
+            return {};
+        });
 }
 
 void EngineBase::handle_setoption(const string_view arguments)

--- a/libchess/src/uci/Printing.cpp
+++ b/libchess/src/uci/Printing.cpp
@@ -34,12 +34,9 @@ using notation::to_uci;
 namespace {
     [[nodiscard]] auto ponder_move_string(const std::optional<Move> ponderMove) -> std::string
     {
-        if (ponderMove.has_value()) {
-            [[likely]];
-            return std::format(" ponder {}", to_uci(*ponderMove));
-        }
-
-        return {};
+        return ponderMove
+            .transform([](const Move move) { return std::format(" ponder {}", to_uci(move)); })
+            .value_or(std::string {});
     }
 } // namespace
 
@@ -54,21 +51,19 @@ void best_move(
 namespace {
     [[nodiscard]] auto base_score_string(const SearchInfo::Score& score) -> std::string
     {
-        if (score.cp.has_value()) {
-            [[likely]];
+        return score.cp.transform([](const int cp) { return std::format("cp {}", cp); })
+            .or_else([&score] {
+                return score.mate.transform([](int pliesToMate) {
+                    // convert plies to moves
+                    if (pliesToMate > 0)
+                        ++pliesToMate;
 
-            return std::format("cp {}", *score.cp);
-        }
+                    const auto mateIn = pliesToMate / 2;
 
-        auto plyToMate = *score.mate;
-
-        if (plyToMate > 0)
-            ++plyToMate;
-
-        // plies -> moves
-        const auto mateIn = plyToMate / 2;
-
-        return std::format("mate {}", mateIn);
+                    return std::format("mate {}", mateIn);
+                });
+            })
+            .value_or(std::string {});
     }
 
     [[nodiscard]] auto score_string(const SearchInfo::Score& score) -> std::string

--- a/tests/rampart/main.cpp
+++ b/tests/rampart/main.cpp
@@ -65,14 +65,20 @@ try {
 
     auto movesJSON = nlohmann::json::array();
 
-    for (const auto position = chess::notation::from_fen(fenString);
-        const auto& move : chess::moves::generate(position)) {
+    const auto position = chess::notation::from_fen(fenString);
+
+    if (not position.has_value()) {
+        std::println(std::cerr, "{}", position.error());
+        return EXIT_FAILURE;
+    }
+
+    for (const auto& move : chess::moves::generate(position.value())) {
         nlohmann::json moveJSON;
 
-        moveJSON["move"] = chess::notation::to_alg(position, move);
+        moveJSON["move"] = chess::notation::to_alg(position.value(), move);
 
         moveJSON["fen"] = chess::notation::to_fen(
-            after_move(position, move),
+            after_move(position.value(), move),
             false);
 
         movesJSON.push_back(moveJSON);

--- a/tests/unit/libbenbot/data-structures/TranspositionTable.cpp
+++ b/tests/unit/libbenbot/data-structures/TranspositionTable.cpp
@@ -39,7 +39,8 @@ TEST_CASE("Transposition table - find()", TAGS)
 
     static const Position startPos {};
 
-    const auto pos2 = notation::from_fen("8/8/4n3/2B1k1p1/3Pn3/2K5/5R2/8 b - - 0 1");
+    const auto pos2 = notation::from_fen("8/8/4n3/2B1k1p1/3Pn3/2K5/5R2/8 b - - 0 1")
+                          .value();
 
     TranspositionTable table;
 

--- a/tests/unit/libbenbot/data-structures/TranspositionTable.cpp
+++ b/tests/unit/libbenbot/data-structures/TranspositionTable.cpp
@@ -66,10 +66,11 @@ TEST_CASE("Transposition table - get_best_response()", TAGS)
 {
     static const Position startPos {};
 
-    const auto ourMove = notation::from_alg(startPos, "Nf3");
+    const auto ourMove = notation::from_alg(startPos, "Nf3").value();
 
     const auto theirMove = notation::from_alg(
-        chess::game::after_move(startPos, ourMove), "Nf6");
+        chess::game::after_move(startPos, ourMove), "Nf6")
+                               .value();
 
     TranspositionTable table;
 

--- a/tests/unit/libchess/board/Square.cpp
+++ b/tests/unit/libchess/board/Square.cpp
@@ -192,13 +192,13 @@ TEST_CASE("Square - is_light()/is_dark()", TAGS)
 }
 
 TEST_CASE("Square - to/from string", TAGS) {
-#define SQUARE_TO_FROM_STRING(str, strLower, file, rank)         \
-    SECTION(str)                                                 \
-    {                                                            \
-        static constexpr Square square { file, rank };           \
-        STATIC_REQUIRE(square == Square::from_string(str));      \
-        STATIC_REQUIRE(square == Square::from_string(strLower)); \
-        REQUIRE(std::format("{}", square) == strLower);          \
+#define SQUARE_TO_FROM_STRING(str, strLower, file, rank)  \
+    SECTION(str)                                          \
+    {                                                     \
+        static constexpr Square square { file, rank };    \
+        REQUIRE(square == Square::from_string(str));      \
+        REQUIRE(square == Square::from_string(strLower)); \
+        REQUIRE(std::format("{}", square) == strLower);   \
     }
 
     // clang-format off

--- a/tests/unit/libchess/game/CastlingRights.cpp
+++ b/tests/unit/libchess/game/CastlingRights.cpp
@@ -75,9 +75,7 @@ TEST_CASE("Castling rights - lost when rook captured", TAGS)
 
         REQUIRE(position.whiteCastlingRights.kingside);
 
-        const auto move = from_alg(position, "Nxh1");
-
-        position.make_move(move);
+        position.make_move(from_alg(position, "Nxh1").value());
 
         REQUIRE(not position.whiteCastlingRights.kingside);
     }
@@ -88,9 +86,7 @@ TEST_CASE("Castling rights - lost when rook captured", TAGS)
 
         REQUIRE(position.whiteCastlingRights.queenside);
 
-        const auto move = from_alg(position, "Bxa1");
-
-        position.make_move(move);
+        position.make_move(from_alg(position, "Bxa1").value());
 
         REQUIRE(not position.whiteCastlingRights.queenside);
     }
@@ -101,9 +97,7 @@ TEST_CASE("Castling rights - lost when rook captured", TAGS)
 
         REQUIRE(position.blackCastlingRights.kingside);
 
-        const auto move = from_alg(position, "Bxh8");
-
-        position.make_move(move);
+        position.make_move(from_alg(position, "Bxh8").value());
 
         REQUIRE(not position.blackCastlingRights.kingside);
     }
@@ -114,9 +108,7 @@ TEST_CASE("Castling rights - lost when rook captured", TAGS)
 
         REQUIRE(position.blackCastlingRights.queenside);
 
-        const auto move = from_alg(position, "Qxa8");
-
-        position.make_move(move);
+        position.make_move(from_alg(position, "Qxa8").value());
 
         REQUIRE(not position.blackCastlingRights.queenside);
     }

--- a/tests/unit/libchess/game/CastlingRights.cpp
+++ b/tests/unit/libchess/game/CastlingRights.cpp
@@ -71,7 +71,8 @@ TEST_CASE("Castling rights - lost when rook captured", TAGS)
 
     SECTION("White - kingside")
     {
-        auto position = from_fen("r1b1kb1r/ppp2ppp/2q1p3/2np4/5P2/1NP1N1P1/PP1PPnBP/R1BQK2R b KQkq - 0 1");
+        auto position = from_fen("r1b1kb1r/ppp2ppp/2q1p3/2np4/5P2/1NP1N1P1/PP1PPnBP/R1BQK2R b KQkq - 0 1")
+                            .value();
 
         REQUIRE(position.whiteCastlingRights.kingside);
 
@@ -82,7 +83,8 @@ TEST_CASE("Castling rights - lost when rook captured", TAGS)
 
     SECTION("White - queenside")
     {
-        auto position = from_fen("r2qk2r/ppp2ppp/2np1n2/4p3/3PPNb1/1Q6/PbPB1PPP/R3KBNR b KQkq - 0 1");
+        auto position = from_fen("r2qk2r/ppp2ppp/2np1n2/4p3/3PPNb1/1Q6/PbPB1PPP/R3KBNR b KQkq - 0 1")
+                            .value();
 
         REQUIRE(position.whiteCastlingRights.queenside);
 
@@ -93,7 +95,8 @@ TEST_CASE("Castling rights - lost when rook captured", TAGS)
 
     SECTION("Black - kingside")
     {
-        auto position = from_fen("rnbqk2r/ppp2pBp/4p3/2bp1n2/3P4/8/PPP1PPPP/RNBQK1NR w KQkq - 0 1");
+        auto position = from_fen("rnbqk2r/ppp2pBp/4p3/2bp1n2/3P4/8/PPP1PPPP/RNBQK1NR w KQkq - 0 1")
+                            .value();
 
         REQUIRE(position.blackCastlingRights.kingside);
 
@@ -104,7 +107,8 @@ TEST_CASE("Castling rights - lost when rook captured", TAGS)
 
     SECTION("Black - queenside")
     {
-        auto position = from_fen("r3kbnr/pQ3ppp/2nq4/3pp3/5Bb1/1N1P4/PPP1PPPP/R3KBNR w KQkq - 0 1");
+        auto position = from_fen("r3kbnr/pQ3ppp/2nq4/3pp3/5Bb1/1N1P4/PPP1PPPP/R3KBNR w KQkq - 0 1")
+                            .value();
 
         REQUIRE(position.blackCastlingRights.queenside);
 

--- a/tests/unit/libchess/game/Position.cpp
+++ b/tests/unit/libchess/game/Position.cpp
@@ -124,7 +124,8 @@ TEST_CASE("Position - is_check()", TAGS)
 
     SECTION("Blocked ray attack")
     {
-        const auto pos = from_fen("r1bqkb1r/pppppppp/2n4n/8/2B1P3/5Q2/PPPP1PPP/RNB1K1NR b KQkq - 4 3");
+        const auto pos = from_fen("r1bqkb1r/pppppppp/2n4n/8/2B1P3/5Q2/PPPP1PPP/RNB1K1NR b KQkq - 4 3")
+                             .value();
 
         REQUIRE(not pos.is_check());
         REQUIRE(not pos.is_checkmate());
@@ -133,7 +134,8 @@ TEST_CASE("Position - is_check()", TAGS)
 
     SECTION("Check")
     {
-        const auto pos = from_fen("r1bqkb1r/pppppB1p/2n4n/6p1/4P3/5Q2/PPPP1PPP/RNB1K1NR b KQkq - 0 4");
+        const auto pos = from_fen("r1bqkb1r/pppppB1p/2n4n/6p1/4P3/5Q2/PPPP1PPP/RNB1K1NR b KQkq - 0 4")
+                             .value();
 
         REQUIRE(pos.is_check());
         REQUIRE(not pos.is_checkmate());
@@ -142,7 +144,8 @@ TEST_CASE("Position - is_check()", TAGS)
 
     SECTION("Checkmate")
     {
-        const auto pos = from_fen("1rbqkbnr/p1pppQpp/1pn5/8/2B1P3/8/PPPP1PPP/RNB1K1NR b KQk - 0 4");
+        const auto pos = from_fen("1rbqkbnr/p1pppQpp/1pn5/8/2B1P3/8/PPPP1PPP/RNB1K1NR b KQk - 0 4")
+                             .value();
 
         REQUIRE(pos.is_check());
         REQUIRE(pos.is_checkmate());
@@ -151,7 +154,8 @@ TEST_CASE("Position - is_check()", TAGS)
 
     SECTION("Stalemate")
     {
-        const auto pos = from_fen("7K/5k2/6q1/8/8/8/8/8 w - - 0 1");
+        const auto pos = from_fen("7K/5k2/6q1/8/8/8/8/8 w - - 0 1")
+                             .value();
 
         REQUIRE(not pos.is_check());
         REQUIRE(not pos.is_checkmate());
@@ -163,14 +167,16 @@ TEST_CASE("Position - stalemate", TAGS)
 {
     SECTION("White is stalemated")
     {
-        const auto position = from_fen("7K/5k2/6q1/8/8/8/8/8 w - - 0 1");
+        const auto position = from_fen("7K/5k2/6q1/8/8/8/8/8 w - - 0 1")
+                                  .value();
 
         REQUIRE(position.is_stalemate());
     }
 
     SECTION("Black is stalemated")
     {
-        const auto position = from_fen("2k5/P7/2K5/6B1/8/8/8/8 b - - 0 1");
+        const auto position = from_fen("2k5/P7/2K5/6B1/8/8/8/8 b - - 0 1")
+                                  .value();
 
         REQUIRE(position.is_stalemate());
     }
@@ -180,14 +186,16 @@ TEST_CASE("Position - checkmate", TAGS)
 {
     SECTION("White is checkmated")
     {
-        const auto position = from_fen("rnb1kb1r/pppppppp/4q3/8/2P5/1B1n4/PP1PPPPP/RN1QKBNR w KQkq - 0 1");
+        const auto position = from_fen("rnb1kb1r/pppppppp/4q3/8/2P5/1B1n4/PP1PPPPP/RN1QKBNR w KQkq - 0 1")
+                                  .value();
 
         REQUIRE(position.is_checkmate());
     }
 
     SECTION("Black is checkmated")
     {
-        const auto position = from_fen("r2qkbnr/ppp1pBpp/2n5/1b1pN3/8/4PQ2/PPPP1PPP/R1B1K1NR b KQkq - 0 1");
+        const auto position = from_fen("r2qkbnr/ppp1pBpp/2n5/1b1pN3/8/4PQ2/PPPP1PPP/R1B1K1NR b KQkq - 0 1")
+                                  .value();
 
         REQUIRE(position.is_checkmate());
     }
@@ -197,35 +205,40 @@ TEST_CASE("Position - draw by insufficient material", TAGS)
 {
     SECTION("Lone kings")
     {
-        const auto position = from_fen("8/8/1K6/8/5k2/8/8/8 w - - 0 1");
+        const auto position = from_fen("8/8/1K6/8/5k2/8/8/8 w - - 0 1")
+                                  .value();
 
         REQUIRE(position.is_draw_by_insufficient_material());
     }
 
     SECTION("White has a single knight")
     {
-        const auto position = from_fen("8/8/1K6/8/5k2/3N4/8/8 b - - 0 1");
+        const auto position = from_fen("8/8/1K6/8/5k2/3N4/8/8 b - - 0 1")
+                                  .value();
 
         REQUIRE(position.is_draw_by_insufficient_material());
     }
 
     SECTION("White has a single bishop")
     {
-        const auto position = from_fen("8/8/1K6/8/5k2/8/8/5B2 b - - 0 1");
+        const auto position = from_fen("8/8/1K6/8/5k2/8/8/5B2 b - - 0 1")
+                                  .value();
 
         REQUIRE(position.is_draw_by_insufficient_material());
     }
 
     SECTION("Black has a single knight")
     {
-        const auto position = from_fen("8/8/1K1n4/8/5k2/8/8/8 w - - 0 1");
+        const auto position = from_fen("8/8/1K1n4/8/5k2/8/8/8 w - - 0 1")
+                                  .value();
 
         REQUIRE(position.is_draw_by_insufficient_material());
     }
 
     SECTION("Black has a single bishop")
     {
-        const auto position = from_fen("8/8/1K6/8/3b1k2/8/8/8 w - - 0 1");
+        const auto position = from_fen("8/8/1K6/8/3b1k2/8/8/8 w - - 0 1")
+                                  .value();
 
         REQUIRE(position.is_draw_by_insufficient_material());
     }
@@ -243,7 +256,8 @@ TEST_CASE("Position - passed pawns", TAGS)
 
     SECTION("White and Black each have a passer")
     {
-        const auto position = from_fen("8/8/2Pk4/8/8/5p2/5K2/8 w - - 0 1");
+        const auto position = from_fen("8/8/2Pk4/8/8/5p2/5K2/8 w - - 0 1")
+                                  .value();
 
         REQUIRE(position.get_passed_pawns<Color::White>().count() == 1uz);
         REQUIRE(position.get_passed_pawns<Color::Black>().count() == 1uz);
@@ -251,7 +265,8 @@ TEST_CASE("Position - passed pawns", TAGS)
 
     SECTION("White has a passer")
     {
-        const auto position = from_fen("8/3Pp3/2p1P3/2P5/1k1K4/5p2/5P2/8 w - - 0 1");
+        const auto position = from_fen("8/3Pp3/2p1P3/2P5/1k1K4/5p2/5P2/8 w - - 0 1")
+                                  .value();
 
         REQUIRE(position.get_passed_pawns<Color::White>().count() == 1uz);
         REQUIRE(position.get_passed_pawns<Color::Black>().count() == 0uz);
@@ -270,7 +285,8 @@ TEST_CASE("Position - backward pawns", TAGS)
 
     SECTION("Telestop weakness")
     {
-        const auto position = from_fen("8/5p2/6p1/p1p3P1/P1P5/7P/1P6/8 w - - 0 1");
+        const auto position = from_fen("8/5p2/6p1/p1p3P1/P1P5/7P/1P6/8 w - - 0 1")
+                                  .value();
 
         const auto wBackwards = position.get_backward_pawns<Color::White>();
 
@@ -302,16 +318,16 @@ TEST_CASE("Position - fifty-move draws", TAGS)
 {
     REQUIRE(! Position {}.is_fifty_move_draw());
 
-    REQUIRE(from_fen("7k/4NK2/5r2/5BN1/8/8/8/8 w - - 103 115").is_fifty_move_draw());
-    REQUIRE(from_fen("8/7k/8/1r3KR1/5B2/8/8/8 w - - 105 122").is_fifty_move_draw());
+    REQUIRE(from_fen("7k/4NK2/5r2/5BN1/8/8/8/8 w - - 103 115").value().is_fifty_move_draw());
+    REQUIRE(from_fen("8/7k/8/1r3KR1/5B2/8/8/8 w - - 105 122").value().is_fifty_move_draw());
 }
 
 TEST_CASE("Position - flip()", TAGS)
 {
     SECTION("Giuoco Piano")
     {
-        const auto initial = from_fen("r1bqk1nr/pppp1ppp/2n5/2b1p3/2B1P3/5N2/PPPP1PPP/RNBQK2R w KQkq - 1 1");
-        const auto correct = from_fen("rnbqk2r/pppp1ppp/5n2/2b1p3/2B1P3/2N5/PPPP1PPP/R1BQK1NR b KQkq - 1 1");
+        const auto initial = from_fen("r1bqk1nr/pppp1ppp/2n5/2b1p3/2B1P3/5N2/PPPP1PPP/RNBQK2R w KQkq - 1 1").value();
+        const auto correct = from_fen("rnbqk2r/pppp1ppp/5n2/2b1p3/2B1P3/2N5/PPPP1PPP/R1BQK1NR b KQkq - 1 1").value();
 
         REQUIRE(flipped(initial) == correct);
         REQUIRE(flipped(correct) == initial);
@@ -319,8 +335,8 @@ TEST_CASE("Position - flip()", TAGS)
 
     SECTION("Giuoco Piano Symmetrical")
     {
-        const auto initial = from_fen("r1bqk2r/pppp1ppp/2n2n2/2b1p3/2B1P3/2N2N2/PPPP1PPP/R1BQK2R w KQkq - 1 1");
-        const auto correct = from_fen("r1bqk2r/pppp1ppp/2n2n2/2b1p3/2B1P3/2N2N2/PPPP1PPP/R1BQK2R b KQkq - 1 1");
+        const auto initial = from_fen("r1bqk2r/pppp1ppp/2n2n2/2b1p3/2B1P3/2N2N2/PPPP1PPP/R1BQK2R w KQkq - 1 1").value();
+        const auto correct = from_fen("r1bqk2r/pppp1ppp/2n2n2/2b1p3/2B1P3/2N2N2/PPPP1PPP/R1BQK2R b KQkq - 1 1").value();
 
         REQUIRE(flipped(initial) == correct);
         REQUIRE(flipped(correct) == initial);

--- a/tests/unit/libchess/game/ThreefoldRepetition.cpp
+++ b/tests/unit/libchess/game/ThreefoldRepetition.cpp
@@ -27,31 +27,31 @@ TEST_CASE("Position - threefold repetitions", TAGS)
 
     REQUIRE(not pos.is_threefold_repetition());
 
-    pos.make_move(from_alg(pos, "Nc3"));
-    pos.make_move(from_alg(pos, "Nc6"));
+    pos.make_move(from_alg(pos, "Nc3").value());
+    pos.make_move(from_alg(pos, "Nc6").value());
 
     REQUIRE(not pos.is_threefold_repetition());
 
-    pos.make_move(from_alg(pos, "Nb1"));
-    pos.make_move(from_alg(pos, "Nb8"));
+    pos.make_move(from_alg(pos, "Nb1").value());
+    pos.make_move(from_alg(pos, "Nb8").value());
 
     REQUIRE(not pos.is_threefold_repetition());
 
-    pos.make_move(from_alg(pos, "Nc3"));
-    pos.make_move(from_alg(pos, "Nc6"));
+    pos.make_move(from_alg(pos, "Nc3").value());
+    pos.make_move(from_alg(pos, "Nc6").value());
 
     REQUIRE(not pos.is_threefold_repetition());
 
-    pos.make_move(from_alg(pos, "Nb1"));
-    pos.make_move(from_alg(pos, "Nb8"));
+    pos.make_move(from_alg(pos, "Nb1").value());
+    pos.make_move(from_alg(pos, "Nb8").value());
 
     REQUIRE(pos.is_threefold_repetition());
 
-    pos.make_move(from_alg(pos, "Nc3"));
+    pos.make_move(from_alg(pos, "Nc3").value());
 
     REQUIRE(pos.is_threefold_repetition());
 
-    pos.make_move(from_alg(pos, "Nc6"));
+    pos.make_move(from_alg(pos, "Nc6").value());
 
     REQUIRE(pos.is_threefold_repetition());
 }
@@ -60,14 +60,14 @@ TEST_CASE("Threefold repetition from differing moves", TAGS)
 {
     chess::game::Position pos {};
 
-    pos.make_move(from_alg(pos, "Nf3"));
-    pos.make_move(from_alg(pos, "Nf6"));
-    pos.make_move(from_alg(pos, "Ng1"));
-    pos.make_move(from_alg(pos, "Ng8"));
-    pos.make_move(from_alg(pos, "Nc3"));
-    pos.make_move(from_alg(pos, "Nc6"));
-    pos.make_move(from_alg(pos, "Nb1"));
-    pos.make_move(from_alg(pos, "Nb8"));
+    pos.make_move(from_alg(pos, "Nf3").value());
+    pos.make_move(from_alg(pos, "Nf6").value());
+    pos.make_move(from_alg(pos, "Ng1").value());
+    pos.make_move(from_alg(pos, "Ng8").value());
+    pos.make_move(from_alg(pos, "Nc3").value());
+    pos.make_move(from_alg(pos, "Nc6").value());
+    pos.make_move(from_alg(pos, "Nb1").value());
+    pos.make_move(from_alg(pos, "Nb8").value());
 
     REQUIRE(pos.is_threefold_repetition());
 }
@@ -77,31 +77,31 @@ TEST_CASE("Position - threefold reps - not threefold if EP possible in starting 
     auto pos = chess::notation::from_fen(
         "rnbqkbnr/ppp1pppp/8/3pP3/8/8/PPPP1PPP/RNBQKBNR w KQkq d6 0 1");
 
-    pos.make_move(from_alg(pos, "Be2"));
-    pos.make_move(from_alg(pos, "Bd7"));
+    pos.make_move(from_alg(pos, "Be2").value());
+    pos.make_move(from_alg(pos, "Bd7").value());
 
     REQUIRE(not pos.is_threefold_repetition());
 
-    pos.make_move(from_alg(pos, "Bf1"));
-    pos.make_move(from_alg(pos, "Bc8"));
+    pos.make_move(from_alg(pos, "Bf1").value());
+    pos.make_move(from_alg(pos, "Bc8").value());
 
     REQUIRE(not pos.is_threefold_repetition());
 
-    pos.make_move(from_alg(pos, "Be2"));
-    pos.make_move(from_alg(pos, "Bd7"));
+    pos.make_move(from_alg(pos, "Be2").value());
+    pos.make_move(from_alg(pos, "Bd7").value());
 
     REQUIRE(not pos.is_threefold_repetition());
 
-    pos.make_move(from_alg(pos, "Bf1"));
-    pos.make_move(from_alg(pos, "Bc8"));
+    pos.make_move(from_alg(pos, "Bf1").value());
+    pos.make_move(from_alg(pos, "Bc8").value());
 
     REQUIRE(not pos.is_threefold_repetition());
 
-    pos.make_move(from_alg(pos, "Be2"));
+    pos.make_move(from_alg(pos, "Be2").value());
 
     REQUIRE(pos.is_threefold_repetition());
 
-    pos.make_move(from_alg(pos, "Bd7"));
+    pos.make_move(from_alg(pos, "Bd7").value());
 
     REQUIRE(pos.is_threefold_repetition());
 }

--- a/tests/unit/libchess/game/ThreefoldRepetition.cpp
+++ b/tests/unit/libchess/game/ThreefoldRepetition.cpp
@@ -75,7 +75,8 @@ TEST_CASE("Threefold repetition from differing moves", TAGS)
 TEST_CASE("Position - threefold reps - not threefold if EP possible in starting position", TAGS)
 {
     auto pos = chess::notation::from_fen(
-        "rnbqkbnr/ppp1pppp/8/3pP3/8/8/PPPP1PPP/RNBQKBNR w KQkq d6 0 1");
+        "rnbqkbnr/ppp1pppp/8/3pP3/8/8/PPPP1PPP/RNBQKBNR w KQkq d6 0 1")
+                   .value();
 
     pos.make_move(from_alg(pos, "Be2").value());
     pos.make_move(from_alg(pos, "Bd7").value());

--- a/tests/unit/libchess/game/ZobristHashing.cpp
+++ b/tests/unit/libchess/game/ZobristHashing.cpp
@@ -29,14 +29,16 @@ TEST_CASE("Zobrist - starting position", TAGS)
 {
     const chess::game::Position startPosition {};
 
-    const auto startPos = from_fen("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1");
+    const auto startPos = from_fen("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1")
+                              .value();
 
     REQUIRE(startPosition.hash == startPos.hash);
 }
 
 TEST_CASE("Zobrist - reaching identical positions", TAGS)
 {
-    const auto position = from_fen("rnbqkbnr/ppp1pppp/8/3P4/8/8/PPPP1PPP/RNBQKBNR b KQkq - 0 2");
+    const auto position = from_fen("rnbqkbnr/ppp1pppp/8/3P4/8/8/PPPP1PPP/RNBQKBNR b KQkq - 0 2")
+                              .value();
 
     chess::game::Position pos {};
 
@@ -67,7 +69,8 @@ TEST_CASE("Zobrist - hash changes", TAGS)
     SECTION("From FEN")
     {
         const auto pos = from_fen(
-            "r3k2r/pppppppp/8/8/8/8/PPPPPPPP/R3K2R w KQkq - 0 1");
+            "r3k2r/pppppppp/8/8/8/8/PPPPPPPP/R3K2R w KQkq - 0 1")
+                             .value();
 
         const auto oldHash = pos.hash;
 
@@ -85,13 +88,14 @@ TEST_CASE("Zobrist - loading identical FENs", TAGS)
         "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQq - 0 1"
     };
 
-    const auto pos1 = from_fen(fen);
-    const auto pos2 = from_fen(fen);
+    const auto pos1 = from_fen(fen).value();
+    const auto pos2 = from_fen(fen).value();
 
     REQUIRE(pos1.hash == pos2.hash);
 
     const auto pos3 = from_fen(
-        "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR b KQq - 0 1");
+        "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR b KQq - 0 1")
+                          .value();
 
     REQUIRE(pos3.hash != pos1.hash);
 }
@@ -112,7 +116,8 @@ TEST_CASE("Zobrist - repeated positions", TAGS)
 
 TEST_CASE("Zobrist - repeated positions, but original had EP possibility", TAGS)
 {
-    auto pos = from_fen("rnbqkbnr/ppp1pppp/8/8/3pP3/8/PPPP1PPP/RNBQKBNR b KQkq e3 0 1");
+    auto pos = from_fen("rnbqkbnr/ppp1pppp/8/8/3pP3/8/PPPP1PPP/RNBQKBNR b KQkq e3 0 1")
+                   .value();
 
     const auto origHash = pos.hash;
 

--- a/tests/unit/libchess/game/ZobristHashing.cpp
+++ b/tests/unit/libchess/game/ZobristHashing.cpp
@@ -40,9 +40,9 @@ TEST_CASE("Zobrist - reaching identical positions", TAGS)
 
     chess::game::Position pos {};
 
-    pos.make_move(from_alg(pos, "e4"));
-    pos.make_move(from_alg(pos, "d5"));
-    pos.make_move(from_alg(pos, "exd5"));
+    pos.make_move(from_alg(pos, "e4").value());
+    pos.make_move(from_alg(pos, "d5").value());
+    pos.make_move(from_alg(pos, "exd5").value());
 
     REQUIRE(pos.hash == position.hash);
 }
@@ -102,10 +102,10 @@ TEST_CASE("Zobrist - repeated positions", TAGS)
 
     const auto origHash = pos.hash;
 
-    pos.make_move(from_alg(pos, "Nf3"));
-    pos.make_move(from_alg(pos, "Nf6"));
-    pos.make_move(from_alg(pos, "Ng1"));
-    pos.make_move(from_alg(pos, "Ng8"));
+    pos.make_move(from_alg(pos, "Nf3").value());
+    pos.make_move(from_alg(pos, "Nf6").value());
+    pos.make_move(from_alg(pos, "Ng1").value());
+    pos.make_move(from_alg(pos, "Ng8").value());
 
     REQUIRE(pos.hash == origHash);
 }
@@ -116,10 +116,10 @@ TEST_CASE("Zobrist - repeated positions, but original had EP possibility", TAGS)
 
     const auto origHash = pos.hash;
 
-    pos.make_move(from_alg(pos, "Bd7"));
-    pos.make_move(from_alg(pos, "Be2"));
-    pos.make_move(from_alg(pos, "Bc8"));
-    pos.make_move(from_alg(pos, "Bf1"));
+    pos.make_move(from_alg(pos, "Bd7").value());
+    pos.make_move(from_alg(pos, "Be2").value());
+    pos.make_move(from_alg(pos, "Bc8").value());
+    pos.make_move(from_alg(pos, "Bf1").value());
 
     REQUIRE(pos.hash != origHash);
 }

--- a/tests/unit/libchess/moves/EnPassant.cpp
+++ b/tests/unit/libchess/moves/EnPassant.cpp
@@ -20,9 +20,11 @@ static constexpr auto TAGS { "[moves][EnPassant]" };
 
 TEST_CASE("En passant - illegal if capture reveals check", TAGS)
 {
-    const auto position = chess::notation::from_fen("4k3/8/8/p1K1Pp1r/Pp5p/6pP/6P1/8 w - f6 0 1");
+    const auto position = chess::notation::from_fen("4k3/8/8/p1K1Pp1r/Pp5p/6pP/6P1/8 w - f6 0 1")
+                              .value();
 
-    const auto move = chess::notation::from_alg(position, "exf6").value();
+    const auto move = chess::notation::from_alg(position, "exf6")
+                          .value();
 
     REQUIRE(not position.is_legal(move));
 }

--- a/tests/unit/libchess/moves/EnPassant.cpp
+++ b/tests/unit/libchess/moves/EnPassant.cpp
@@ -22,7 +22,7 @@ TEST_CASE("En passant - illegal if capture reveals check", TAGS)
 {
     const auto position = chess::notation::from_fen("4k3/8/8/p1K1Pp1r/Pp5p/6pP/6P1/8 w - f6 0 1");
 
-    const auto move = chess::notation::from_alg(position, "exf6");
+    const auto move = chess::notation::from_alg(position, "exf6").value();
 
     REQUIRE(not position.is_legal(move));
 }

--- a/tests/unit/libchess/moves/Legal.cpp
+++ b/tests/unit/libchess/moves/Legal.cpp
@@ -23,7 +23,8 @@ using chess::notation::from_fen;
 
 TEST_CASE("Maximum known moves in a position", TAGS)
 {
-    const auto position = from_fen("R6R/3Q4/1Q4Q1/4Q3/2Q4Q/Q4Q2/pp1Q4/kBNN1KB1 w - - 0 1");
+    const auto position = from_fen("R6R/3Q4/1Q4Q1/4Q3/2Q4Q/Q4Q2/pp1Q4/kBNN1KB1 w - - 0 1")
+                              .value();
 
     const auto moves = generate(position);
 
@@ -34,21 +35,24 @@ TEST_CASE("Captures only", TAGS)
 {
     SECTION("No captures")
     {
-        const auto position = from_fen("r3k2r/Pppp1ppp/1b3nbN/nP6/BBP1P3/q4N2/Pp1P2PP/R2Q1RK1 w kq - 0 1");
+        const auto position = from_fen("r3k2r/Pppp1ppp/1b3nbN/nP6/BBP1P3/q4N2/Pp1P2PP/R2Q1RK1 w kq - 0 1")
+                                  .value();
 
         REQUIRE(generate<true>(position).empty());
     }
 
     SECTION("Kiwipete")
     {
-        const auto position = from_fen("r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1p/PPPBBPPP/R3K2R w KQkq - 0 1");
+        const auto position = from_fen("r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1p/PPPBBPPP/R3K2R w KQkq - 0 1")
+                                  .value();
 
         REQUIRE(generate<true>(position).size() == 8uz);
     }
 
     SECTION("Rook/pawn endgame")
     {
-        const auto position = from_fen("8/2p5/3p4/KP5r/1R3p1k/8/4P1P1/8 w - - 0 1");
+        const auto position = from_fen("8/2p5/3p4/KP5r/1R3p1k/8/4P1P1/8 w - - 0 1")
+                                  .value();
 
         REQUIRE(generate<true>(position).size() == 1uz);
     }

--- a/tests/unit/libchess/notation/Algebraic.cpp
+++ b/tests/unit/libchess/notation/Algebraic.cpp
@@ -42,7 +42,7 @@ TEST_CASE("Algebraic notation - piece moves", TAGS)
         Position position {};
 
         {
-            const auto move = from_alg(position, "Nc3");
+            const auto move = from_alg(position, "Nc3").value();
 
             REQUIRE(move.piece() == PieceType::Knight);
             REQUIRE(move.to() == Square { File::C, Rank::Three });
@@ -53,7 +53,7 @@ TEST_CASE("Algebraic notation - piece moves", TAGS)
             position.make_move(move);
         }
 
-        const auto move = from_alg(position, "Nf6");
+        const auto move = from_alg(position, "Nf6").value();
 
         REQUIRE(move.piece() == PieceType::Knight);
         REQUIRE(move.to() == Square { File::F, Rank::Six });
@@ -67,7 +67,7 @@ TEST_CASE("Algebraic notation - piece moves", TAGS)
         auto position = from_fen("8/4b2P/r3k3/4qn2/1Q2P3/3pRK2/3B4/8 w - - 0 1");
 
         {
-            const auto move = from_alg(position, "Bc3");
+            const auto move = from_alg(position, "Bc3").value();
 
             REQUIRE(move.piece() == PieceType::Bishop);
             REQUIRE(move.to() == Square { File::C, Rank::Three });
@@ -79,7 +79,7 @@ TEST_CASE("Algebraic notation - piece moves", TAGS)
         }
 
         {
-            const auto move = from_alg(position, "Bxb4");
+            const auto move = from_alg(position, "Bxb4").value();
 
             REQUIRE(move.piece() == PieceType::Bishop);
             REQUIRE(move.to() == Square { File::B, Rank::Four });
@@ -93,7 +93,7 @@ TEST_CASE("Algebraic notation - piece moves", TAGS)
         }
 
         {
-            const auto move = from_alg(position, "Bxe5");
+            const auto move = from_alg(position, "Bxe5").value();
 
             REQUIRE(move.piece() == PieceType::Bishop);
             REQUIRE(move.to() == Square { File::E, Rank::Five });
@@ -115,7 +115,7 @@ TEST_CASE("Algebraic notation - piece moves", TAGS)
         auto position = from_fen("r7/8/3n1r2/4k3/2bRppqP/1Pr5/3KNB2/R7 w - - 0 1");
 
         {
-            const auto move = from_alg(position, "Rg1");
+            const auto move = from_alg(position, "Rg1").value();
 
             REQUIRE(move.piece() == PieceType::Rook);
             REQUIRE(move.to() == Square { File::G, Rank::One });
@@ -127,7 +127,7 @@ TEST_CASE("Algebraic notation - piece moves", TAGS)
         }
 
         {
-            const auto move = from_alg(position, "Ra2+");
+            const auto move = from_alg(position, "Ra2+").value();
 
             REQUIRE(move.piece() == PieceType::Rook);
             REQUIRE(move.to() == Square { File::A, Rank::Two });
@@ -148,7 +148,7 @@ TEST_CASE("Algebraic notation - piece moves", TAGS)
             auto position = from_fen("r2qkbnr/p1p1pppp/2np4/1p6/2B1P1b1/5Q2/PPPP1PPP/RNB1K1NR w KQkq - 0 1");
 
             {
-                const auto move = from_alg(position, "Qxf7+");
+                const auto move = from_alg(position, "Qxf7+").value();
 
                 REQUIRE(move.piece() == PieceType::Queen);
                 REQUIRE(move.to() == Square { File::F, Rank::Seven });
@@ -175,7 +175,7 @@ TEST_CASE("Algebraic notation - piece moves", TAGS)
         {
             auto position = from_fen("r1bqk1nr/pppnpp1p/3p2pb/8/8/1B3Q2/PPPPPPPP/RNB1K1NR w KQkq - 0 1");
 
-            const auto move = from_alg(position, "Qxf7#");
+            const auto move = from_alg(position, "Qxf7#").value();
 
             REQUIRE(move.piece() == PieceType::Queen);
             REQUIRE(move.to() == Square { File::F, Rank::Seven });
@@ -198,7 +198,7 @@ TEST_CASE("Algebraic notation - piece moves", TAGS)
         REQUIRE(position.is_check());
 
         {
-            const auto move = from_alg(position, "Kxc6");
+            const auto move = from_alg(position, "Kxc6").value();
 
             REQUIRE(move.piece() == PieceType::King);
             REQUIRE(move.to() == Square { File::C, Rank::Six });
@@ -212,7 +212,7 @@ TEST_CASE("Algebraic notation - piece moves", TAGS)
         REQUIRE(! position.is_check());
 
         {
-            const auto move = from_alg(position, "Kxf6");
+            const auto move = from_alg(position, "Kxf6").value();
 
             REQUIRE(move.piece() == PieceType::King);
             REQUIRE(move.to() == Square { File::F, Rank::Six });
@@ -232,7 +232,7 @@ TEST_CASE("Algebraic notation - piece moves with disambiguation", TAGS)
             const auto position = from_fen("1kr2b1r/ppp1pppp/3q1n2/2np1b2/2B1P3/1NB2N2/PPPPQPPP/R4RK1 w Qk - 0 1");
 
             { // F knight
-                const auto move = from_alg(position, "Nfd4");
+                const auto move = from_alg(position, "Nfd4").value();
 
                 REQUIRE(move.piece() == PieceType::Knight);
                 REQUIRE(move.to() == Square { File::D, Rank::Four });
@@ -241,7 +241,7 @@ TEST_CASE("Algebraic notation - piece moves with disambiguation", TAGS)
                 REQUIRE(to_alg(position, move) == "Nfd4");
             }
             { // B knight
-                const auto move = from_alg(position, "Nbd4");
+                const auto move = from_alg(position, "Nbd4").value();
 
                 REQUIRE(move.piece() == PieceType::Knight);
                 REQUIRE(move.to() == Square { File::D, Rank::Four });
@@ -256,7 +256,7 @@ TEST_CASE("Algebraic notation - piece moves with disambiguation", TAGS)
             const auto position = from_fen("6r1/2k5/1p1pq1p1/p7/R2QP3/1N3P1P/8/KN6 w - - 0 1");
 
             { // 3 knight
-                const auto move = from_alg(position, "N3d2");
+                const auto move = from_alg(position, "N3d2").value();
 
                 REQUIRE(move.piece() == PieceType::Knight);
                 REQUIRE(move.to() == Square { File::D, Rank::Two });
@@ -265,7 +265,7 @@ TEST_CASE("Algebraic notation - piece moves with disambiguation", TAGS)
                 REQUIRE(to_alg(position, move) == "N3d2");
             }
             { // 1 knight
-                const auto move = from_alg(position, "N1d2");
+                const auto move = from_alg(position, "N1d2").value();
 
                 REQUIRE(move.piece() == PieceType::Knight);
                 REQUIRE(move.to() == Square { File::D, Rank::Two });
@@ -279,7 +279,7 @@ TEST_CASE("Algebraic notation - piece moves with disambiguation", TAGS)
         {
             const auto position = from_fen("rn1qkbnr/ppp1pppp/3p4/8/4P1b1/1NQ2N2/PPPP1PPP/R1BK1B1R w KQkq - 0 1");
 
-            const auto move = from_alg(position, "Nd4");
+            const auto move = from_alg(position, "Nd4").value();
 
             REQUIRE(move.piece() == PieceType::Knight);
             REQUIRE(move.to() == Square { File::D, Rank::Four });
@@ -296,7 +296,7 @@ TEST_CASE("Algebraic notation - piece moves with disambiguation", TAGS)
             const auto position = from_fen("r7/8/8/5k2/2R1R3/6n1/1K6/8 w - - 0 1");
 
             { // E rook
-                const auto move = from_alg(position, "Red4");
+                const auto move = from_alg(position, "Red4").value();
 
                 REQUIRE(move.piece() == PieceType::Rook);
                 REQUIRE(move.to() == Square { File::D, Rank::Four });
@@ -305,7 +305,7 @@ TEST_CASE("Algebraic notation - piece moves with disambiguation", TAGS)
                 REQUIRE(to_alg(position, move) == "Red4");
             }
             { // C rook
-                const auto move = from_alg(position, "Rcd4");
+                const auto move = from_alg(position, "Rcd4").value();
 
                 REQUIRE(move.piece() == PieceType::Rook);
                 REQUIRE(move.to() == Square { File::D, Rank::Four });
@@ -314,7 +314,7 @@ TEST_CASE("Algebraic notation - piece moves with disambiguation", TAGS)
                 REQUIRE(to_alg(position, move) == "Rcd4");
             }
             {
-                const auto move = from_alg(position, "Ra4");
+                const auto move = from_alg(position, "Ra4").value();
 
                 REQUIRE(move.piece() == PieceType::Rook);
                 REQUIRE(move.to() == Square { File::A, Rank::Four });
@@ -323,7 +323,7 @@ TEST_CASE("Algebraic notation - piece moves with disambiguation", TAGS)
                 REQUIRE(to_alg(position, move) == "Ra4");
             }
             {
-                const auto move = from_alg(position, "Ra4");
+                const auto move = from_alg(position, "Ra4").value();
 
                 REQUIRE(move.piece() == PieceType::Rook);
                 REQUIRE(move.to() == Square { File::A, Rank::Four });
@@ -332,7 +332,7 @@ TEST_CASE("Algebraic notation - piece moves with disambiguation", TAGS)
                 REQUIRE(to_alg(position, move) == "Ra4");
             }
             {
-                const auto move = from_alg(position, "Rf4+");
+                const auto move = from_alg(position, "Rf4+").value();
 
                 REQUIRE(move.piece() == PieceType::Rook);
                 REQUIRE(move.to() == Square { File::F, Rank::Four });
@@ -347,7 +347,7 @@ TEST_CASE("Algebraic notation - piece moves with disambiguation", TAGS)
             const auto position = from_fen("kr6/p7/1r2q3/8/3B4/2Q3N1/3K1P1P/8 b - - 0 1");
 
             { // 8 rook
-                const auto move = from_alg(position, "R8b7");
+                const auto move = from_alg(position, "R8b7").value();
 
                 REQUIRE(move.piece() == PieceType::Rook);
                 REQUIRE(move.to() == Square { File::B, Rank::Seven });
@@ -356,7 +356,7 @@ TEST_CASE("Algebraic notation - piece moves with disambiguation", TAGS)
                 REQUIRE(to_alg(position, move) == "R8b7");
             }
             { // 6 rook
-                const auto move = from_alg(position, "R6b7");
+                const auto move = from_alg(position, "R6b7").value();
 
                 REQUIRE(move.piece() == PieceType::Rook);
                 REQUIRE(move.to() == Square { File::B, Rank::Seven });
@@ -365,7 +365,7 @@ TEST_CASE("Algebraic notation - piece moves with disambiguation", TAGS)
                 REQUIRE(to_alg(position, move) == "R6b7");
             }
             {
-                const auto move = from_alg(position, "Rb3");
+                const auto move = from_alg(position, "Rb3").value();
 
                 REQUIRE(move.piece() == PieceType::Rook);
                 REQUIRE(move.to() == Square { File::B, Rank::Three });
@@ -379,7 +379,7 @@ TEST_CASE("Algebraic notation - piece moves with disambiguation", TAGS)
         {
             const auto position = from_fen("5k2/8/8/q7/6b1/8/1R2R3/3K4 w - - 0 1");
 
-            const auto move = from_alg(position, "Rc2");
+            const auto move = from_alg(position, "Rc2").value();
 
             REQUIRE(move.piece() == PieceType::Rook);
             REQUIRE(move.to() == Square { File::C, Rank::Two });
@@ -396,7 +396,7 @@ TEST_CASE("Algebraic notation - pawn pushes", TAGS)
     {
         const Position startingPosition {};
 
-        const auto move = from_alg(startingPosition, "e3");
+        const auto move = from_alg(startingPosition, "e3").value();
 
         REQUIRE(move.piece() == PieceType::Pawn);
         REQUIRE(move.to() == Square { File::E, Rank::Three });
@@ -409,7 +409,7 @@ TEST_CASE("Algebraic notation - pawn pushes", TAGS)
     {
         auto position = from_fen("rnbqkb1r/p1p1pppp/3P4/1pp4n/2Q2B2/5N2/PPP1PPPP/RN2KB1R w KQkq - 0 1");
 
-        const auto move = from_alg(position, "d7+");
+        const auto move = from_alg(position, "d7+").value();
 
         REQUIRE(move.piece() == PieceType::Pawn);
         REQUIRE(move.to() == Square { File::D, Rank::Seven });
@@ -426,7 +426,7 @@ TEST_CASE("Algebraic notation - pawn pushes", TAGS)
     {
         auto position = from_fen("8/2N5/1B6/8/k7/P7/KP6/8 w - - 0 1");
 
-        const auto move = from_alg(position, "b3#");
+        const auto move = from_alg(position, "b3#").value();
 
         REQUIRE(move.piece() == PieceType::Pawn);
         REQUIRE(move.to() == Square { File::B, Rank::Three });
@@ -446,7 +446,7 @@ TEST_CASE("Algebraic notation - pawn double pushes", TAGS)
     {
         Position startingPosition {};
 
-        const auto move = from_alg(startingPosition, "e4");
+        const auto move = from_alg(startingPosition, "e4").value();
 
         REQUIRE(move.piece() == PieceType::Pawn);
         REQUIRE(move.to() == Square { File::E, Rank::Four });
@@ -465,7 +465,7 @@ TEST_CASE("Algebraic notation - pawn double pushes", TAGS)
     {
         auto position = from_fen("8/8/8/4k3/8/8/2KP4/8 w - - 0 1");
 
-        const auto move = from_alg(position, "d4+");
+        const auto move = from_alg(position, "d4+").value();
 
         REQUIRE(move.piece() == PieceType::Pawn);
         REQUIRE(move.to() == Square { File::D, Rank::Four });
@@ -486,7 +486,7 @@ TEST_CASE("Algebraic notation - pawn double pushes", TAGS)
     {
         auto position = from_fen("4q3/6p1/8/2r5/5k1K/7P/8/6r1 b - - 0 1");
 
-        const auto move = from_alg(position, "g5#");
+        const auto move = from_alg(position, "g5#").value();
 
         REQUIRE(move.piece() == PieceType::Pawn);
         REQUIRE(move.to() == Square { File::G, Rank::Five });
@@ -510,7 +510,7 @@ TEST_CASE("Algebraic notation - pawn captures", TAGS)
     {
         const auto position = from_fen("rnbqkbnr/ppp1pppp/8/3p4/4P3/8/PPPP1PPP/RNBQKBNR w KQkq - 0 1");
 
-        const auto move = from_alg(position, "exd5");
+        const auto move = from_alg(position, "exd5").value();
 
         REQUIRE(move.piece() == PieceType::Pawn);
         REQUIRE(move.to() == Square { File::D, Rank::Five });
@@ -523,7 +523,7 @@ TEST_CASE("Algebraic notation - pawn captures", TAGS)
     {
         auto position = from_fen("r2qkbnr/p2ppppp/npp1P3/1b6/6N1/2Q5/PPPP1PPP/RNB1KB1R w KQkq - 0 1");
 
-        const auto move = from_alg(position, "exd7+");
+        const auto move = from_alg(position, "exd7+").value();
 
         REQUIRE(move.piece() == PieceType::Pawn);
         REQUIRE(move.to() == Square { File::D, Rank::Seven });
@@ -540,7 +540,7 @@ TEST_CASE("Algebraic notation - pawn captures", TAGS)
     {
         auto position = from_fen("r1b1kb1r/ppp1p1pp/5p2/6Q1/5q1N/1Pn3p1/P1PPPPPP/R1BnKB1R b KQkq - 0 1");
 
-        const auto move = from_alg(position, "gxf2#");
+        const auto move = from_alg(position, "gxf2#").value();
 
         REQUIRE(move.piece() == PieceType::Pawn);
         REQUIRE(move.to() == Square { File::F, Rank::Two });
@@ -560,7 +560,7 @@ TEST_CASE("Algebraic notation - promotion (push)", TAGS)
     {
         auto position = from_fen("8/1k1P4/8/2r5/8/8/4K3/8 w - - 0 1");
 
-        const auto move = from_alg(position, "d8=Q");
+        const auto move = from_alg(position, "d8=Q").value();
 
         REQUIRE(move.piece() == PieceType::Pawn);
         REQUIRE(move.to() == Square { File::D, Rank::Eight });
@@ -583,7 +583,7 @@ TEST_CASE("Algebraic notation - promotion (push)", TAGS)
     {
         auto position = from_fen("8/1k1P4/8/2r5/8/8/4K3/8 w - - 0 1");
 
-        const auto move = from_alg(position, "d8=N+");
+        const auto move = from_alg(position, "d8=N+").value();
 
         REQUIRE(move.piece() == PieceType::Pawn);
         REQUIRE(move.to() == Square { File::D, Rank::Eight });
@@ -608,7 +608,7 @@ TEST_CASE("Algebraic notation - promotion (push)", TAGS)
     {
         auto position = from_fen("k7/ppP5/8/5K2/8/8/8/8 w - - 0 1");
 
-        const auto move = from_alg(position, "c8=R#");
+        const auto move = from_alg(position, "c8=R#").value();
 
         REQUIRE(move.piece() == PieceType::Pawn);
         REQUIRE(move.to() == Square { File::C, Rank::Eight });
@@ -631,7 +631,7 @@ TEST_CASE("Algebraic notation - promotion (capture)", TAGS)
     {
         auto position = from_fen("3r4/2K1Pk2/8/8/8/8/8/8 w - - 0 1");
 
-        const auto move = from_alg(position, "exd8=B");
+        const auto move = from_alg(position, "exd8=B").value();
 
         REQUIRE(move.piece() == PieceType::Pawn);
         REQUIRE(move.to() == Square { File::D, Rank::Eight });
@@ -655,7 +655,7 @@ TEST_CASE("Algebraic notation - promotion (capture)", TAGS)
     {
         auto position = from_fen("8/8/8/8/8/2k5/4p3/2KQ4 b - - 0 1");
 
-        const auto move = from_alg(position, "exd1=Q+");
+        const auto move = from_alg(position, "exd1=Q+").value();
 
         REQUIRE(move.piece() == PieceType::Pawn);
         REQUIRE(move.to() == Square { File::D, Rank::One });
@@ -675,7 +675,7 @@ TEST_CASE("Algebraic notation - promotion (capture)", TAGS)
     {
         auto position = from_fen("b2r4/1k1NP3/8/K7/1r6/8/2R5/6B1 w - - 0 1");
 
-        const auto move = from_alg(position, "exd8=N#");
+        const auto move = from_alg(position, "exd8=N#").value();
 
         REQUIRE(move.piece() == PieceType::Pawn);
         REQUIRE(move.to() == Square { File::D, Rank::Eight });
@@ -700,7 +700,7 @@ TEST_CASE("Algebraic notation - kingside castling", TAGS)
         {
             auto position = from_fen("rnbqkb1r/ppp1pppp/3p1n2/8/2B1P3/5N2/PPPP1PPP/RNBQK2R w KQkq - 0 1");
 
-            const auto move = from_alg(position, "O-O");
+            const auto move = from_alg(position, "O-O").value();
 
             REQUIRE(move.is_castling());
             REQUIRE(move.piece() == PieceType::King);
@@ -718,7 +718,7 @@ TEST_CASE("Algebraic notation - kingside castling", TAGS)
         {
             auto position = from_fen("rnbqk2r/pp1ppppp/2p5/1b3n2/8/1B1P1Q2/PPP1PPPP/RN2KBNR b KQkq - 0 1");
 
-            const auto move = from_alg(position, "O-O");
+            const auto move = from_alg(position, "O-O").value();
 
             REQUIRE(move.is_castling());
             REQUIRE(move.piece() == PieceType::King);
@@ -739,7 +739,7 @@ TEST_CASE("Algebraic notation - kingside castling", TAGS)
         {
             auto position = from_fen("rnbq1knr/ppppp1pp/2b5/8/8/1QNBP3/PPPP2PP/RNB1K2R w KQkq - 0 1");
 
-            const auto move = from_alg(position, "O-O+");
+            const auto move = from_alg(position, "O-O+").value();
 
             REQUIRE(move.is_castling());
             REQUIRE(move.piece() == PieceType::King);
@@ -759,7 +759,7 @@ TEST_CASE("Algebraic notation - kingside castling", TAGS)
         {
             auto position = from_fen("rnbqk2r/ppp1p1pp/7b/3p4/2B1N3/4nK2/PPPPP1PP/RNBQ1R2 b kq - 0 1");
 
-            const auto move = from_alg(position, "O-O+");
+            const auto move = from_alg(position, "O-O+").value();
 
             REQUIRE(move.is_castling());
             REQUIRE(move.piece() == PieceType::King);
@@ -782,7 +782,7 @@ TEST_CASE("Algebraic notation - kingside castling", TAGS)
         {
             auto position = from_fen("8/8/8/7N/2BQ4/5k2/8/4K2R w K - 0 1");
 
-            const auto move = from_alg(position, "O-O#");
+            const auto move = from_alg(position, "O-O#").value();
 
             REQUIRE(move.is_castling());
             REQUIRE(move.piece() == PieceType::King);
@@ -802,7 +802,7 @@ TEST_CASE("Algebraic notation - kingside castling", TAGS)
         {
             auto position = from_fen("4k2r/8/8/8/8/3n2r1/7r/5K2 b k - 0 1");
 
-            const auto move = from_alg(position, "O-O#");
+            const auto move = from_alg(position, "O-O#").value();
 
             REQUIRE(move.is_castling());
             REQUIRE(move.piece() == PieceType::King);
@@ -828,7 +828,7 @@ TEST_CASE("Algebraic notation - queenside castling", TAGS)
         {
             auto position = from_fen("rn1qkbnr/pppp1ppp/3b4/4p3/8/2NP1Q2/PPPBPPPP/R3KBNR w KQkq - 0 1");
 
-            const auto move = from_alg(position, "O-O-O");
+            const auto move = from_alg(position, "O-O-O").value();
 
             REQUIRE(move.is_castling());
             REQUIRE(move.piece() == PieceType::King);
@@ -846,7 +846,7 @@ TEST_CASE("Algebraic notation - queenside castling", TAGS)
         {
             auto position = from_fen("r3kbnr/ppp1pppp/n7/2qp1b2/8/3PB3/PPPQPPPP/RN2KBNR b KQkq - 0 1");
 
-            const auto move = from_alg(position, "O-O-O");
+            const auto move = from_alg(position, "O-O-O").value();
 
             REQUIRE(move.is_castling());
             REQUIRE(move.piece() == PieceType::King);
@@ -865,7 +865,7 @@ TEST_CASE("Algebraic notation - queenside castling", TAGS)
     {
         auto position = from_fen("rn1k1bnr/ppp1pppp/4b3/5q2/4N3/2B2Q2/PPP1PPPP/R3KBNR w KQkq - 0 1");
 
-        const auto move = from_alg(position, "O-O-O+");
+        const auto move = from_alg(position, "O-O-O+").value();
 
         REQUIRE(move.is_castling());
         REQUIRE(move.piece() == PieceType::King);
@@ -885,7 +885,7 @@ TEST_CASE("Algebraic notation - queenside castling", TAGS)
     {
         auto position = from_fen("r3kb2/ppp1pppp/8/8/6b1/8/1PP1PPnP/r1NKnBNR b Kq - 0 1");
 
-        const auto move = from_alg(position, "O-O-O#");
+        const auto move = from_alg(position, "O-O-O#").value();
 
         REQUIRE(move.is_castling());
         REQUIRE(move.piece() == PieceType::King);

--- a/tests/unit/libchess/notation/Algebraic.cpp
+++ b/tests/unit/libchess/notation/Algebraic.cpp
@@ -64,7 +64,8 @@ TEST_CASE("Algebraic notation - piece moves", TAGS)
 
     SECTION("Bishops")
     {
-        auto position = from_fen("8/4b2P/r3k3/4qn2/1Q2P3/3pRK2/3B4/8 w - - 0 1");
+        auto position = from_fen("8/4b2P/r3k3/4qn2/1Q2P3/3pRK2/3B4/8 w - - 0 1")
+                            .value();
 
         {
             const auto move = from_alg(position, "Bc3").value();
@@ -112,7 +113,8 @@ TEST_CASE("Algebraic notation - piece moves", TAGS)
 
     SECTION("Rooks")
     {
-        auto position = from_fen("r7/8/3n1r2/4k3/2bRppqP/1Pr5/3KNB2/R7 w - - 0 1");
+        auto position = from_fen("r7/8/3n1r2/4k3/2bRppqP/1Pr5/3KNB2/R7 w - - 0 1")
+                            .value();
 
         {
             const auto move = from_alg(position, "Rg1").value();
@@ -145,7 +147,8 @@ TEST_CASE("Algebraic notation - piece moves", TAGS)
     {
         SECTION("Check")
         {
-            auto position = from_fen("r2qkbnr/p1p1pppp/2np4/1p6/2B1P1b1/5Q2/PPPP1PPP/RNB1K1NR w KQkq - 0 1");
+            auto position = from_fen("r2qkbnr/p1p1pppp/2np4/1p6/2B1P1b1/5Q2/PPPP1PPP/RNB1K1NR w KQkq - 0 1")
+                                .value();
 
             {
                 const auto move = from_alg(position, "Qxf7+").value();
@@ -173,7 +176,8 @@ TEST_CASE("Algebraic notation - piece moves", TAGS)
 
         SECTION("Checkmate")
         {
-            auto position = from_fen("r1bqk1nr/pppnpp1p/3p2pb/8/8/1B3Q2/PPPPPPPP/RNB1K1NR w KQkq - 0 1");
+            auto position = from_fen("r1bqk1nr/pppnpp1p/3p2pb/8/8/1B3Q2/PPPPPPPP/RNB1K1NR w KQkq - 0 1")
+                                .value();
 
             const auto move = from_alg(position, "Qxf7#").value();
 
@@ -193,7 +197,8 @@ TEST_CASE("Algebraic notation - piece moves", TAGS)
 
     SECTION("King")
     {
-        auto position = from_fen("8/3k1p2/2P2rp1/4K3/R7/6n1/8/8 b - - 0 1");
+        auto position = from_fen("8/3k1p2/2P2rp1/4K3/R7/6n1/8/8 b - - 0 1")
+                            .value();
 
         REQUIRE(position.is_check());
 
@@ -229,7 +234,8 @@ TEST_CASE("Algebraic notation - piece moves with disambiguation", TAGS)
     {
         SECTION("Disambig required (by file)")
         {
-            const auto position = from_fen("1kr2b1r/ppp1pppp/3q1n2/2np1b2/2B1P3/1NB2N2/PPPPQPPP/R4RK1 w Qk - 0 1");
+            const auto position = from_fen("1kr2b1r/ppp1pppp/3q1n2/2np1b2/2B1P3/1NB2N2/PPPPQPPP/R4RK1 w Qk - 0 1")
+                                      .value();
 
             { // F knight
                 const auto move = from_alg(position, "Nfd4").value();
@@ -253,7 +259,8 @@ TEST_CASE("Algebraic notation - piece moves with disambiguation", TAGS)
 
         SECTION("Disambig required (by rank)")
         {
-            const auto position = from_fen("6r1/2k5/1p1pq1p1/p7/R2QP3/1N3P1P/8/KN6 w - - 0 1");
+            const auto position = from_fen("6r1/2k5/1p1pq1p1/p7/R2QP3/1N3P1P/8/KN6 w - - 0 1")
+                                      .value();
 
             { // 3 knight
                 const auto move = from_alg(position, "N3d2").value();
@@ -277,7 +284,8 @@ TEST_CASE("Algebraic notation - piece moves with disambiguation", TAGS)
 
         SECTION("Disambig not required")
         {
-            const auto position = from_fen("rn1qkbnr/ppp1pppp/3p4/8/4P1b1/1NQ2N2/PPPP1PPP/R1BK1B1R w KQkq - 0 1");
+            const auto position = from_fen("rn1qkbnr/ppp1pppp/3p4/8/4P1b1/1NQ2N2/PPPP1PPP/R1BK1B1R w KQkq - 0 1")
+                                      .value();
 
             const auto move = from_alg(position, "Nd4").value();
 
@@ -293,7 +301,8 @@ TEST_CASE("Algebraic notation - piece moves with disambiguation", TAGS)
     {
         SECTION("Disambig required (by file)")
         {
-            const auto position = from_fen("r7/8/8/5k2/2R1R3/6n1/1K6/8 w - - 0 1");
+            const auto position = from_fen("r7/8/8/5k2/2R1R3/6n1/1K6/8 w - - 0 1")
+                                      .value();
 
             { // E rook
                 const auto move = from_alg(position, "Red4").value();
@@ -344,7 +353,8 @@ TEST_CASE("Algebraic notation - piece moves with disambiguation", TAGS)
 
         SECTION("Disambig required (by rank)")
         {
-            const auto position = from_fen("kr6/p7/1r2q3/8/3B4/2Q3N1/3K1P1P/8 b - - 0 1");
+            const auto position = from_fen("kr6/p7/1r2q3/8/3B4/2Q3N1/3K1P1P/8 b - - 0 1")
+                                      .value();
 
             { // 8 rook
                 const auto move = from_alg(position, "R8b7").value();
@@ -377,7 +387,8 @@ TEST_CASE("Algebraic notation - piece moves with disambiguation", TAGS)
 
         SECTION("Disambig not required")
         {
-            const auto position = from_fen("5k2/8/8/q7/6b1/8/1R2R3/3K4 w - - 0 1");
+            const auto position = from_fen("5k2/8/8/q7/6b1/8/1R2R3/3K4 w - - 0 1")
+                                      .value();
 
             const auto move = from_alg(position, "Rc2").value();
 
@@ -407,7 +418,8 @@ TEST_CASE("Algebraic notation - pawn pushes", TAGS)
 
     SECTION("With check")
     {
-        auto position = from_fen("rnbqkb1r/p1p1pppp/3P4/1pp4n/2Q2B2/5N2/PPP1PPPP/RN2KB1R w KQkq - 0 1");
+        auto position = from_fen("rnbqkb1r/p1p1pppp/3P4/1pp4n/2Q2B2/5N2/PPP1PPPP/RN2KB1R w KQkq - 0 1")
+                            .value();
 
         const auto move = from_alg(position, "d7+").value();
 
@@ -424,7 +436,8 @@ TEST_CASE("Algebraic notation - pawn pushes", TAGS)
 
     SECTION("With checkmate")
     {
-        auto position = from_fen("8/2N5/1B6/8/k7/P7/KP6/8 w - - 0 1");
+        auto position = from_fen("8/2N5/1B6/8/k7/P7/KP6/8 w - - 0 1")
+                            .value();
 
         const auto move = from_alg(position, "b3#").value();
 
@@ -463,7 +476,8 @@ TEST_CASE("Algebraic notation - pawn double pushes", TAGS)
 
     SECTION("With check")
     {
-        auto position = from_fen("8/8/8/4k3/8/8/2KP4/8 w - - 0 1");
+        auto position = from_fen("8/8/8/4k3/8/8/2KP4/8 w - - 0 1")
+                            .value();
 
         const auto move = from_alg(position, "d4+").value();
 
@@ -484,7 +498,8 @@ TEST_CASE("Algebraic notation - pawn double pushes", TAGS)
 
     SECTION("With checkmate")
     {
-        auto position = from_fen("4q3/6p1/8/2r5/5k1K/7P/8/6r1 b - - 0 1");
+        auto position = from_fen("4q3/6p1/8/2r5/5k1K/7P/8/6r1 b - - 0 1")
+                            .value();
 
         const auto move = from_alg(position, "g5#").value();
 
@@ -508,7 +523,8 @@ TEST_CASE("Algebraic notation - pawn captures", TAGS)
 {
     SECTION("Normal")
     {
-        const auto position = from_fen("rnbqkbnr/ppp1pppp/8/3p4/4P3/8/PPPP1PPP/RNBQKBNR w KQkq - 0 1");
+        const auto position = from_fen("rnbqkbnr/ppp1pppp/8/3p4/4P3/8/PPPP1PPP/RNBQKBNR w KQkq - 0 1")
+                                  .value();
 
         const auto move = from_alg(position, "exd5").value();
 
@@ -521,7 +537,8 @@ TEST_CASE("Algebraic notation - pawn captures", TAGS)
 
     SECTION("With check")
     {
-        auto position = from_fen("r2qkbnr/p2ppppp/npp1P3/1b6/6N1/2Q5/PPPP1PPP/RNB1KB1R w KQkq - 0 1");
+        auto position = from_fen("r2qkbnr/p2ppppp/npp1P3/1b6/6N1/2Q5/PPPP1PPP/RNB1KB1R w KQkq - 0 1")
+                            .value();
 
         const auto move = from_alg(position, "exd7+").value();
 
@@ -538,7 +555,8 @@ TEST_CASE("Algebraic notation - pawn captures", TAGS)
 
     SECTION("With checkmate")
     {
-        auto position = from_fen("r1b1kb1r/ppp1p1pp/5p2/6Q1/5q1N/1Pn3p1/P1PPPPPP/R1BnKB1R b KQkq - 0 1");
+        auto position = from_fen("r1b1kb1r/ppp1p1pp/5p2/6Q1/5q1N/1Pn3p1/P1PPPPPP/R1BnKB1R b KQkq - 0 1")
+                            .value();
 
         const auto move = from_alg(position, "gxf2#").value();
 
@@ -558,7 +576,8 @@ TEST_CASE("Algebraic notation - promotion (push)", TAGS)
 {
     SECTION("Normal")
     {
-        auto position = from_fen("8/1k1P4/8/2r5/8/8/4K3/8 w - - 0 1");
+        auto position = from_fen("8/1k1P4/8/2r5/8/8/4K3/8 w - - 0 1")
+                            .value();
 
         const auto move = from_alg(position, "d8=Q").value();
 
@@ -581,7 +600,8 @@ TEST_CASE("Algebraic notation - promotion (push)", TAGS)
 
     SECTION("With check")
     {
-        auto position = from_fen("8/1k1P4/8/2r5/8/8/4K3/8 w - - 0 1");
+        auto position = from_fen("8/1k1P4/8/2r5/8/8/4K3/8 w - - 0 1")
+                            .value();
 
         const auto move = from_alg(position, "d8=N+").value();
 
@@ -606,7 +626,8 @@ TEST_CASE("Algebraic notation - promotion (push)", TAGS)
 
     SECTION("With checkmate")
     {
-        auto position = from_fen("k7/ppP5/8/5K2/8/8/8/8 w - - 0 1");
+        auto position = from_fen("k7/ppP5/8/5K2/8/8/8/8 w - - 0 1")
+                            .value();
 
         const auto move = from_alg(position, "c8=R#").value();
 
@@ -629,7 +650,8 @@ TEST_CASE("Algebraic notation - promotion (capture)", TAGS)
 {
     SECTION("Normal")
     {
-        auto position = from_fen("3r4/2K1Pk2/8/8/8/8/8/8 w - - 0 1");
+        auto position = from_fen("3r4/2K1Pk2/8/8/8/8/8/8 w - - 0 1")
+                            .value();
 
         const auto move = from_alg(position, "exd8=B").value();
 
@@ -653,7 +675,8 @@ TEST_CASE("Algebraic notation - promotion (capture)", TAGS)
 
     SECTION("With check")
     {
-        auto position = from_fen("8/8/8/8/8/2k5/4p3/2KQ4 b - - 0 1");
+        auto position = from_fen("8/8/8/8/8/2k5/4p3/2KQ4 b - - 0 1")
+                            .value();
 
         const auto move = from_alg(position, "exd1=Q+").value();
 
@@ -673,7 +696,8 @@ TEST_CASE("Algebraic notation - promotion (capture)", TAGS)
 
     SECTION("With checkmate")
     {
-        auto position = from_fen("b2r4/1k1NP3/8/K7/1r6/8/2R5/6B1 w - - 0 1");
+        auto position = from_fen("b2r4/1k1NP3/8/K7/1r6/8/2R5/6B1 w - - 0 1")
+                            .value();
 
         const auto move = from_alg(position, "exd8=N#").value();
 
@@ -698,7 +722,8 @@ TEST_CASE("Algebraic notation - kingside castling", TAGS)
     {
         SECTION("White")
         {
-            auto position = from_fen("rnbqkb1r/ppp1pppp/3p1n2/8/2B1P3/5N2/PPPP1PPP/RNBQK2R w KQkq - 0 1");
+            auto position = from_fen("rnbqkb1r/ppp1pppp/3p1n2/8/2B1P3/5N2/PPPP1PPP/RNBQK2R w KQkq - 0 1")
+                                .value();
 
             const auto move = from_alg(position, "O-O").value();
 
@@ -716,7 +741,8 @@ TEST_CASE("Algebraic notation - kingside castling", TAGS)
 
         SECTION("Black")
         {
-            auto position = from_fen("rnbqk2r/pp1ppppp/2p5/1b3n2/8/1B1P1Q2/PPP1PPPP/RN2KBNR b KQkq - 0 1");
+            auto position = from_fen("rnbqk2r/pp1ppppp/2p5/1b3n2/8/1B1P1Q2/PPP1PPPP/RN2KBNR b KQkq - 0 1")
+                                .value();
 
             const auto move = from_alg(position, "O-O").value();
 
@@ -737,7 +763,8 @@ TEST_CASE("Algebraic notation - kingside castling", TAGS)
     {
         SECTION("White")
         {
-            auto position = from_fen("rnbq1knr/ppppp1pp/2b5/8/8/1QNBP3/PPPP2PP/RNB1K2R w KQkq - 0 1");
+            auto position = from_fen("rnbq1knr/ppppp1pp/2b5/8/8/1QNBP3/PPPP2PP/RNB1K2R w KQkq - 0 1")
+                                .value();
 
             const auto move = from_alg(position, "O-O+").value();
 
@@ -757,7 +784,8 @@ TEST_CASE("Algebraic notation - kingside castling", TAGS)
 
         SECTION("Black")
         {
-            auto position = from_fen("rnbqk2r/ppp1p1pp/7b/3p4/2B1N3/4nK2/PPPPP1PP/RNBQ1R2 b kq - 0 1");
+            auto position = from_fen("rnbqk2r/ppp1p1pp/7b/3p4/2B1N3/4nK2/PPPPP1PP/RNBQ1R2 b kq - 0 1")
+                                .value();
 
             const auto move = from_alg(position, "O-O+").value();
 
@@ -780,7 +808,8 @@ TEST_CASE("Algebraic notation - kingside castling", TAGS)
     {
         SECTION("White")
         {
-            auto position = from_fen("8/8/8/7N/2BQ4/5k2/8/4K2R w K - 0 1");
+            auto position = from_fen("8/8/8/7N/2BQ4/5k2/8/4K2R w K - 0 1")
+                                .value();
 
             const auto move = from_alg(position, "O-O#").value();
 
@@ -800,7 +829,8 @@ TEST_CASE("Algebraic notation - kingside castling", TAGS)
 
         SECTION("Black")
         {
-            auto position = from_fen("4k2r/8/8/8/8/3n2r1/7r/5K2 b k - 0 1");
+            auto position = from_fen("4k2r/8/8/8/8/3n2r1/7r/5K2 b k - 0 1")
+                                .value();
 
             const auto move = from_alg(position, "O-O#").value();
 
@@ -826,7 +856,8 @@ TEST_CASE("Algebraic notation - queenside castling", TAGS)
     {
         SECTION("White")
         {
-            auto position = from_fen("rn1qkbnr/pppp1ppp/3b4/4p3/8/2NP1Q2/PPPBPPPP/R3KBNR w KQkq - 0 1");
+            auto position = from_fen("rn1qkbnr/pppp1ppp/3b4/4p3/8/2NP1Q2/PPPBPPPP/R3KBNR w KQkq - 0 1")
+                                .value();
 
             const auto move = from_alg(position, "O-O-O").value();
 
@@ -844,7 +875,8 @@ TEST_CASE("Algebraic notation - queenside castling", TAGS)
 
         SECTION("Black")
         {
-            auto position = from_fen("r3kbnr/ppp1pppp/n7/2qp1b2/8/3PB3/PPPQPPPP/RN2KBNR b KQkq - 0 1");
+            auto position = from_fen("r3kbnr/ppp1pppp/n7/2qp1b2/8/3PB3/PPPQPPPP/RN2KBNR b KQkq - 0 1")
+                                .value();
 
             const auto move = from_alg(position, "O-O-O").value();
 
@@ -863,7 +895,8 @@ TEST_CASE("Algebraic notation - queenside castling", TAGS)
 
     SECTION("With check")
     {
-        auto position = from_fen("rn1k1bnr/ppp1pppp/4b3/5q2/4N3/2B2Q2/PPP1PPPP/R3KBNR w KQkq - 0 1");
+        auto position = from_fen("rn1k1bnr/ppp1pppp/4b3/5q2/4N3/2B2Q2/PPP1PPPP/R3KBNR w KQkq - 0 1")
+                            .value();
 
         const auto move = from_alg(position, "O-O-O+").value();
 
@@ -883,7 +916,8 @@ TEST_CASE("Algebraic notation - queenside castling", TAGS)
 
     SECTION("With checkmate")
     {
-        auto position = from_fen("r3kb2/ppp1pppp/8/8/6b1/8/1PP1PPnP/r1NKnBNR b Kq - 0 1");
+        auto position = from_fen("r3kb2/ppp1pppp/8/8/6b1/8/1PP1PPnP/r1NKnBNR b Kq - 0 1")
+                            .value();
 
         const auto move = from_alg(position, "O-O-O#").value();
 

--- a/tests/unit/libchess/notation/EPD.cpp
+++ b/tests/unit/libchess/notation/EPD.cpp
@@ -25,7 +25,8 @@ TEST_CASE("EPD - start position", TAGS)
 {
     const chess::game::Position startPos {};
 
-    const auto epd = from_epd("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - hmvc 0; fmvn 1;");
+    const auto epd = from_epd("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - hmvc 0; fmvn 1;")
+                         .value();
 
     REQUIRE(epd.position == startPos);
 }
@@ -35,7 +36,8 @@ TEST_CASE("EPD - operations", TAGS)
     using namespace std::literals::string_literals; // NOLINT
 
     const auto epd = from_epd(
-        R"-(r1bqk2r/p1pp1ppp/2p2n2/8/1b2P3/2N5/PPP2PPP/R1BQKB1R w KQkq - bm Bd3; id "Crafty Test Pos.28"; c0 "DB/GK Philadelphia 1996, Game 5, move 7W (Bd3)";)-");
+        R"-(r1bqk2r/p1pp1ppp/2p2n2/8/1b2P3/2N5/PPP2PPP/R1BQKB1R w KQkq - bm Bd3; id "Crafty Test Pos.28"; c0 "DB/GK Philadelphia 1996, Game 5, move 7W (Bd3)";)-")
+                         .value();
 
     REQUIRE(epd.operations.at("bm"s) == "Bd3");
     REQUIRE(epd.operations.at("id"s) == "Crafty Test Pos.28");
@@ -48,7 +50,8 @@ TEST_CASE("EPD - round tripping", TAGS)
 
     // note that fmvn & hmvc operations will be added by to_epd() by default if not present in the input EPD
     const auto epd1 = from_epd(
-        R"-(r1bqk2r/p1pp1ppp/2p2n2/8/1b2P3/2N5/PPP2PPP/R1BQKB1R w KQkq - bm Bd3; id "Crafty Test Pos.28"; c0 "DB/GK Philadelphia 1996, Game 5, move 7W (Bd3)"; fmvn 1; hmvc 1)-");
+        R"-(r1bqk2r/p1pp1ppp/2p2n2/8/1b2P3/2N5/PPP2PPP/R1BQKB1R w KQkq - bm Bd3; id "Crafty Test Pos.28"; c0 "DB/GK Philadelphia 1996, Game 5, move 7W (Bd3)"; fmvn 1; hmvc 1)-")
+                          .value();
 
     const auto epd2 = from_epd(to_epd(epd1));
 

--- a/tests/unit/libchess/notation/FEN.cpp
+++ b/tests/unit/libchess/notation/FEN.cpp
@@ -53,7 +53,7 @@ TEST_CASE("FEN - starting position", TAGS)
 
     SECTION("From FEN")
     {
-        const auto pos = from_fen(startingFEN);
+        const auto pos = from_fen(startingFEN).value();
 
         REQUIRE(pos == startingPos);
 
@@ -70,7 +70,7 @@ TEST_CASE("FEN - after E4", TAGS)
         "rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq e3 0 1"
     };
 
-    const auto pos = from_fen(correctFEN);
+    const auto pos = from_fen(correctFEN).value();
 
     const auto roundTripped = to_fen(pos);
 
@@ -89,7 +89,7 @@ TEST_CASE("FEN - after E4 C5", TAGS)
         "rnbqkbnr/pp1ppppp/8/2p5/4P3/8/PPPP1PPP/RNBQKBNR w KQkq c6 0 2"
     };
 
-    const auto roundTripped = to_fen(from_fen(correctFEN));
+    const auto roundTripped = to_fen(from_fen(correctFEN).value());
 
     REQUIRE_THAT(roundTripped,
         match::Matches(correctFEN.data(), Catch::CaseSensitive::Yes));
@@ -101,7 +101,7 @@ TEST_CASE("FEN - after E4 C5 Nf3", TAGS)
         "rnbqkbnr/pp1ppppp/8/2p5/4P3/5N2/PPPP1PPP/RNBQKB1R b KQkq - 1 2"
     };
 
-    const auto roundTripped = to_fen(from_fen(correctFEN));
+    const auto roundTripped = to_fen(from_fen(correctFEN).value());
 
     REQUIRE_THAT(roundTripped,
         match::Matches(correctFEN.data(), Catch::CaseSensitive::Yes));

--- a/tests/unit/libchess/notation/PGN.cpp
+++ b/tests/unit/libchess/notation/PGN.cpp
@@ -43,7 +43,7 @@ TEST_CASE("PGN - block comments", TAGS)
 1.e4 e5 2.Nf3 Nc6 3.Bb5 {This opening is called the Ruy Lopez.} 3...a6 4.Ba4 Nf6 5.O-O Be7 6.Re1 b5 7.Bb3 d6 8.c3 O-O 9.h3 Nb8 10.d4 Nbd7 11.c4 c6 12.cxb5 axb5 13.Nc3 Bb7 14.Bg5 b4 15.Nb1 h6 16.Bh4 c5 17.dxe5 Nxe4 18.Bxe7 Qxe7 19.exd6 Qf6 20.Nbd2 Nxd6 21.Nc4 Nxc4 22.Bxc4 Nb6 23.Ne5 Rae8 24.Bxf7+ Rxf7 25.Nxf7 Rxe1+ 26.Qxe1 Kxf7 27.Qe3 Qg5 28.Qxg5 hxg5 29.b3 Ke6 30.a3 Kd6 31.axb4 cxb4 32.Ra5 Nd5 33.f3 Bc8 34.Kf2 Bf5 35.Ra7 g6 36.Ra6+ Kc5 37.Ke1 Nf4 38.g3 Nxh3 39.Kd2 Kb5 40.Rd6 Kc5 41.Ra6 Nf2 42.g4 Bd3 43.Re6 1/2-1/2)"
     };
 
-    const auto game = from_pgn(pgn);
+    const auto game = from_pgn(pgn).value();
 
     REQUIRE(game.metadata.size() == 7uz);
 
@@ -77,7 +77,7 @@ TEST_CASE("PGN - tolerate spaces between move number and move", TAGS)
 1. e4 e5 2. Nf3 Nc6 3. Bb5 {This opening is called the Ruy Lopez.} 3. ... a6 4. Ba4 Nf6 5. O-O Be7 6. Re1 b5 7. Bb3 d6 8. c3 O-O 9. h3 Nb8 10. d4 Nbd7)"
     };
 
-    const auto game = from_pgn(pgn);
+    const auto game = from_pgn(pgn).value();
 
     REQUIRE(game.moves.size() == 20uz);
 
@@ -99,7 +99,7 @@ TEST_CASE("PGN - multiline block comments", TAGS)
 called the Ruy Lopez.} 3...a6 4.Ba4 Nf6 5.O-O Be7 6.Re1 b5 7.Bb3 d6 8.c3 O-O 9.h3 Nb8 10.d4 Nbd7 11.c4 c6 12.cxb5 axb5 13.Nc3 Bb7 14.Bg5 b4 15.Nb1 h6 16.Bh4 c5 17.dxe5 Nxe4 18.Bxe7 Qxe7 19.exd6 Qf6 20.Nbd2 Nxd6 21.Nc4 Nxc4 22.Bxc4 Nb6 23.Ne5 Rae8 24.Bxf7+ Rxf7 25.Nxf7 Rxe1+ 26.Qxe1 Kxf7 27.Qe3 Qg5 28.Qxg5 hxg5 29.b3 Ke6 30.a3 Kd6 31.axb4 cxb4 32.Ra5 Nd5 33.f3 Bc8 34.Kf2 Bf5 35.Ra7 g6 36.Ra6+ Kc5 37.Ke1 Nf4 38.g3 Nxh3 39.Kd2 Kb5 40.Rd6 Kc5 41.Ra6 Nf2 42.g4 Bd3 43.Re6 1/2-1/2)"
     };
 
-    const auto game = from_pgn(pgn);
+    const auto game = from_pgn(pgn).value();
 
     static constexpr std::string_view comment {
         R"(This opening is
@@ -126,7 +126,7 @@ TEST_CASE("PGN - line comments", TAGS)
 3...a6 4.Ba4 Nf6 5.O-O Be7 6.Re1 b5 7.Bb3 d6 8.c3 O-O 9.h3 Nb8 10.d4 Nbd7 11.c4 c6 12.cxb5 axb5 13.Nc3 Bb7 14.Bg5 b4 15.Nb1 h6 16.Bh4 c5 17.dxe5 Nxe4 18.Bxe7 Qxe7 19.exd6 Qf6 20.Nbd2 Nxd6 21.Nc4 Nxc4 22.Bxc4 Nb6 23.Ne5 Rae8 24.Bxf7+ Rxf7 25.Nxf7 Rxe1+ 26.Qxe1 Kxf7 27.Qe3 Qg5 28.Qxg5 hxg5 29.b3 Ke6 30.a3 Kd6 31.axb4 cxb4 32.Ra5 Nd5 33.f3 Bc8 34.Kf2 Bf5 35.Ra7 g6 36.Ra6+ Kc5 37.Ke1 Nf4 38.g3 Nxh3 39.Kd2 Kb5 40.Rd6 Kc5 41.Ra6 Nf2 42.g4 Bd3 43.Re6 1/2-1/2)"
     };
 
-    const auto game = from_pgn(pgn);
+    const auto game = from_pgn(pgn).value();
 
     REQUIRE(game.metadata.size() == 7uz);
 
@@ -160,7 +160,7 @@ TEST_CASE("PGN - NAGs", TAGS)
 1.e4 $1 $14 e5 $4)"
     };
 
-    const auto game = from_pgn(pgn);
+    const auto game = from_pgn(pgn).value();
 
     REQUIRE(game.moves.size() == 2uz);
 
@@ -197,7 +197,7 @@ TEST_CASE("PGN - NAG inside a comment", TAGS)
 1.e4 $1 {$14} 1...e5 $4)"
     };
 
-    const auto game = from_pgn(pgn);
+    const auto game = from_pgn(pgn).value();
 
     REQUIRE(game.moves.size() == 2uz);
 
@@ -235,11 +235,11 @@ TEST_CASE("PGN - null NAGs", TAGS)
 1.e4 e5)"
     };
 
-    auto game = from_pgn(pgn);
+    auto game = from_pgn(pgn).value();
 
     game.moves.front().nags.emplace_back(chess::notation::NAG::Null);
 
-    const auto roundTripped = from_pgn(to_pgn(game));
+    const auto roundTripped = from_pgn(to_pgn(game)).value();
 
     REQUIRE(roundTripped.moves.front().nags.empty());
 }
@@ -254,11 +254,11 @@ TEST_CASE("PGN - custom starting position", TAGS)
 1...Ne6 2.Re5)"
     };
 
-    const auto game = from_pgn(pgn);
+    const auto game = from_pgn(pgn).value();
 
     REQUIRE(game.moves.size() == 2uz);
 
-    REQUIRE(game.startingPosition == chess::notation::from_fen("5r2/4k3/8/3R2n1/2K5/8/8/8 b - - 0 1"));
+    REQUIRE(game.startingPosition == chess::notation::from_fen("5r2/4k3/8/3R2n1/2K5/8/8/8 b - - 0 1").value());
 }
 
 TEST_CASE("PGN - variations", TAGS)
@@ -275,7 +275,7 @@ TEST_CASE("PGN - variations", TAGS)
 1.e4 e5 2.Nf3 Nc6 3.Bb5 (3.d4 exd4) 3...a6)"
     };
 
-    const auto game = from_pgn(pgn);
+    const auto game = from_pgn(pgn).value();
 
     REQUIRE(game.moves.size() == 6uz);
 
@@ -304,7 +304,7 @@ TEST_CASE("PGN - nested variations", TAGS)
 1.e4 e5 2.Nf3 Nc6 3.Bb5 (3.d4 exd4 4.Nxd4 (4.Bf4) 4...Nxd4) 3...a6)"
     };
 
-    const auto game = from_pgn(pgn);
+    const auto game = from_pgn(pgn).value();
 
     REQUIRE(game.moves.size() == 6uz);
 
@@ -339,7 +339,7 @@ TEST_CASE("PGN - complex file", TAGS)
 1.e4 c5 2.Nf3 e6 3.d4 cxd4 4.Nxd4 Nc6 5.Nc3 d6 6.g4 a6 7.Be3 Nge7 $5 $146 {An unstandard move for the Sicilian. This prepares the knight to move up the board to f5 later in the game.} 8.Nb3 b5 9.f4 Bb7 10.Qf3 $4 g5 $3 {Polgar sees that Shirov has lined up his queen on the a8-h1 diagonal, with a discovered pin of Shirov's e4 pawn by the bishop once the knight on c6 moves, so she decides to pounce right away. Polgar wants to force the f4 pawn to move so she can play Ne5.} 11.fxg5 (11.f5 Ne5 {If Shirov had advanced his f pawn instead of taking on g5, Polgar could have played Ne5 anyway.}) (11.O-O-O {Shirov probably should have simply ignored the pawn motion on the queenside and castled his king to safety, forcing Polgar to take on f4 if she wants to play Ne5. Shirov can prevent this move by recapturing e5 with his queen.} 11...gxf4 12.Qxf4) 11...Ne5 12.Qg2 $2 {Shirov spends a tempo moving his queen, but still keeps it on the dangerous a8-h1 diagonal, keeping his a4 pawn pinned.} (12.Qe2 b4 13.Na4 Bxe4) 12...b4 {Kicking away the knight that is defending the pinned e4 pawn.} 13.Ne2 h5 $3 {Polgar wants to play Nf5, so she wants to force the g4 pawn to move.} 14.gxh5 (14.gxh6 f5 $3 {If Shirov had captured the h5 pawn with en passant, Polgar still could have forced the g4 pawn to move by sacrificing her last remaining kingside pawn.} 15.gxf5 (15.g5 Bxe4) 15...Nxf5) 14...Nf5 15.Bf2 (15.exf5 $3 {If Shirov had sacrificed his queen, he would be left with a somewhat even game, losing his queen for a knight and a bishop.} 15...Bxg2 16.Bxg2 Rc8) 15...Qxg5 $3 16.Na5 (16.Qxg5 Nf3+ 17.Kd1 Nxg5) 16...Ne3 $1 {Now that the knight has vacated the F5 square, Polgar is happy to leave her light-squared bishop hanging and give up the pin of the e4 pawn in order to keep her attack towards the king going.} 17.Qg3 Qxg3 $6 {Polgar probably already wanted to begin simplifying towards a winning endgame.} (17...Nxc2+ 18.Kd1 Qxh5 $3 19.Kxc2 (19.Nxb7 Nxa1) 19...Bxe4+ {Polgar can win the E4 pawn and move her bishop out of danger in exchange for a knight.} (19...Rc8+)) 18.Nxg3 Nxc2+ 19.Kd1 Nxa1 $18 20.Nxb7 b3 $1 {Polgar is sacrificing this pawn to save the knight.} 21.axb3 (21.a3 Nc2) 21...Nxb3 22.Kc2 Nc5 23.Nxc5 dxc5 24.Be1 Nf3 25.Bc3 Nd4+ {Polgar offers to trade her knight for Shirov's dark-squared bishop.} 26.Kd3 Bd6 27.Bg2 Be5 28.Kc4 Ke7 29.Ra1 (29.Kxc5 Rhc8+ 30.Kb4 Rab8+ 31.Ka3 Nc2+ (31...Nb5+ 32.Ka2 Nxc3+ 33.bxc3 Rxc3 $20) 32.Ka2 Bxc3 33.bxc3 Rxc3 $20) 29...Nc6 0-1)"
     };
 
-    const auto game = from_pgn(pgn);
+    const auto game = from_pgn(pgn).value();
 
     REQUIRE(to_pgn(game) == pgn);
 }

--- a/tests/unit/libchess/notation/UCI.cpp
+++ b/tests/unit/libchess/notation/UCI.cpp
@@ -39,7 +39,7 @@ TEST_CASE("UCI notation - normal moves", TAGS)
 
     SECTION("Pawn move")
     {
-        const auto move = from_uci(startingPosition, "e2e4");
+        const auto move = from_uci(startingPosition, "e2e4").value();
 
         REQUIRE(move.from() == Square { File::E, Rank::Two });
         REQUIRE(move.to() == Square { File::E, Rank::Four });
@@ -50,7 +50,7 @@ TEST_CASE("UCI notation - normal moves", TAGS)
 
     SECTION("Piece move")
     {
-        const auto move = from_uci(startingPosition, "g1f3");
+        const auto move = from_uci(startingPosition, "g1f3").value();
 
         REQUIRE(move.from() == Square { File::G, Rank::One });
         REQUIRE(move.to() == Square { File::F, Rank::Three });
@@ -67,7 +67,7 @@ TEST_CASE("UCI notation - captures", TAGS)
         const auto position = from_fen("rnbqkbnr/ppp1pppp/8/3p4/4P3/8/PPPP1PPP/RNBQKBNR w KQkq - 0 2")
                                   .value();
 
-        const auto move = from_uci(position, "e4d5");
+        const auto move = from_uci(position, "e4d5").value();
 
         REQUIRE(move.from() == Square { File::E, Rank::Four });
         REQUIRE(move.to() == Square { File::D, Rank::Five });
@@ -81,7 +81,7 @@ TEST_CASE("UCI notation - captures", TAGS)
         const auto position = from_fen("rn2kbnr/ppp1pppp/3q4/3p4/4P1b1/2N2N2/PPPPQPPP/R1B1KB1R b KQkq - 5 4")
                                   .value();
 
-        const auto move = from_uci(position, "g4f3");
+        const auto move = from_uci(position, "g4f3").value();
 
         REQUIRE(move.from() == Square { File::G, Rank::Four });
         REQUIRE(move.to() == Square { File::F, Rank::Three });
@@ -96,7 +96,7 @@ TEST_CASE("UCI notation - check", TAGS)
     auto position = from_fen("3rkbnr/ppp1ppp1/2nq4/3p2Np/4P1b1/2N2Q2/PPPP1PPP/R1B1KB1R w KQk - 0 7")
                         .value();
 
-    const auto move = from_uci(position, "f3f7");
+    const auto move = from_uci(position, "f3f7").value();
 
     REQUIRE(move.from() == Square { File::F, Rank::Three });
     REQUIRE(move.to() == Square { File::F, Rank::Seven });
@@ -115,7 +115,7 @@ TEST_CASE("UCI notation - checkmate", TAGS)
     auto position = from_fen("3rkbnr/pppqppp1/2n5/1N1p2Np/4P1b1/5Q2/PPPP1PPP/R1B1KB1R w KQk - 2 8")
                         .value();
 
-    const auto move = from_uci(position, "f3f7");
+    const auto move = from_uci(position, "f3f7").value();
 
     REQUIRE(move.from() == Square { File::F, Rank::Three });
     REQUIRE(move.to() == Square { File::F, Rank::Seven });
@@ -136,7 +136,7 @@ TEST_CASE("UCI notation - castle kingside", TAGS)
         const auto position = from_fen("r1bqkbnr/pppp1ppp/2n5/4p3/8/2BP1N2/PPP1PPPP/RNBQK2R w KQkq - 0 1")
                                   .value();
 
-        const auto move = from_uci(position, "e1g1");
+        const auto move = from_uci(position, "e1g1").value();
 
         REQUIRE(move.from() == Square { File::E, Rank::One });
         REQUIRE(move.to() == Square { File::G, Rank::One });
@@ -152,7 +152,7 @@ TEST_CASE("UCI notation - castle kingside", TAGS)
         const auto position = from_fen("rnbqk2r/ppp2ppp/2bp1n2/4p3/2BP4/4PN2/PPP2PPP/RNBQ1RK1 b Qkq - 0 1")
                                   .value();
 
-        const auto move = from_uci(position, "e8g8");
+        const auto move = from_uci(position, "e8g8").value();
 
         REQUIRE(move.from() == Square { File::E, Rank::Eight });
         REQUIRE(move.to() == Square { File::G, Rank::Eight });
@@ -171,7 +171,7 @@ TEST_CASE("UCI notation - castle queenside", TAGS)
         const auto position = from_fen("rnb1kb1r/pp1pp1pp/1qp1np2/8/3P1B2/2N5/PPPQPPPP/R3KBNR w KQkq - 0 1")
                                   .value();
 
-        const auto move = from_uci(position, "e1c1");
+        const auto move = from_uci(position, "e1c1").value();
 
         REQUIRE(move.from() == Square { File::E, Rank::One });
         REQUIRE(move.to() == Square { File::C, Rank::One });
@@ -187,7 +187,7 @@ TEST_CASE("UCI notation - castle queenside", TAGS)
         const auto position = from_fen("r3kbnr/pppqpppp/2np4/8/3P1Bb1/2N1P3/PPP2PPP/R2QKBNR b KQkq - 0 1")
                                   .value();
 
-        const auto move = from_uci(position, "e8c8");
+        const auto move = from_uci(position, "e8c8").value();
 
         REQUIRE(move.from() == Square { File::E, Rank::Eight });
         REQUIRE(move.to() == Square { File::C, Rank::Eight });
@@ -206,7 +206,7 @@ TEST_CASE("UCI notation - promotions", TAGS)
         const auto position = from_fen("8/8/2rk4/8/6Q1/1K2N3/2p5/8 b - - 0 1")
                                   .value();
 
-        const auto move = from_uci(position, "c2c1b");
+        const auto move = from_uci(position, "c2c1b").value();
 
         REQUIRE(move.from() == Square { File::C, Rank::Two });
         REQUIRE(move.to() == Square { File::C, Rank::One });
@@ -223,7 +223,7 @@ TEST_CASE("UCI notation - promotions", TAGS)
         const auto position = from_fen("4r3/1k1K1P2/8/2qN4/8/8/8/8 w - - 0 1")
                                   .value();
 
-        const auto move = from_uci(position, "f7g8q");
+        const auto move = from_uci(position, "f7g8q").value();
 
         REQUIRE(move.from() == Square { File::F, Rank::Seven });
         REQUIRE(move.to() == Square { File::G, Rank::Eight });
@@ -240,7 +240,7 @@ TEST_CASE("UCI notation - null moves", TAGS)
 {
     const chess::game::Position position {};
 
-    const auto move = from_uci(position, "0000");
+    const auto move = from_uci(position, "0000").value();
 
     REQUIRE(move.is_null());
 

--- a/tests/unit/libchess/notation/UCI.cpp
+++ b/tests/unit/libchess/notation/UCI.cpp
@@ -64,7 +64,8 @@ TEST_CASE("UCI notation - captures", TAGS)
 {
     SECTION("Pawn capture")
     {
-        const auto position = from_fen("rnbqkbnr/ppp1pppp/8/3p4/4P3/8/PPPP1PPP/RNBQKBNR w KQkq - 0 2");
+        const auto position = from_fen("rnbqkbnr/ppp1pppp/8/3p4/4P3/8/PPPP1PPP/RNBQKBNR w KQkq - 0 2")
+                                  .value();
 
         const auto move = from_uci(position, "e4d5");
 
@@ -77,7 +78,8 @@ TEST_CASE("UCI notation - captures", TAGS)
 
     SECTION("Piece capture")
     {
-        const auto position = from_fen("rn2kbnr/ppp1pppp/3q4/3p4/4P1b1/2N2N2/PPPPQPPP/R1B1KB1R b KQkq - 5 4");
+        const auto position = from_fen("rn2kbnr/ppp1pppp/3q4/3p4/4P1b1/2N2N2/PPPPQPPP/R1B1KB1R b KQkq - 5 4")
+                                  .value();
 
         const auto move = from_uci(position, "g4f3");
 
@@ -91,7 +93,8 @@ TEST_CASE("UCI notation - captures", TAGS)
 
 TEST_CASE("UCI notation - check", TAGS)
 {
-    auto position = from_fen("3rkbnr/ppp1ppp1/2nq4/3p2Np/4P1b1/2N2Q2/PPPP1PPP/R1B1KB1R w KQk - 0 7");
+    auto position = from_fen("3rkbnr/ppp1ppp1/2nq4/3p2Np/4P1b1/2N2Q2/PPPP1PPP/R1B1KB1R w KQk - 0 7")
+                        .value();
 
     const auto move = from_uci(position, "f3f7");
 
@@ -109,7 +112,8 @@ TEST_CASE("UCI notation - check", TAGS)
 
 TEST_CASE("UCI notation - checkmate", TAGS)
 {
-    auto position = from_fen("3rkbnr/pppqppp1/2n5/1N1p2Np/4P1b1/5Q2/PPPP1PPP/R1B1KB1R w KQk - 2 8");
+    auto position = from_fen("3rkbnr/pppqppp1/2n5/1N1p2Np/4P1b1/5Q2/PPPP1PPP/R1B1KB1R w KQk - 2 8")
+                        .value();
 
     const auto move = from_uci(position, "f3f7");
 
@@ -129,7 +133,8 @@ TEST_CASE("UCI notation - castle kingside", TAGS)
 {
     SECTION("White")
     {
-        const auto position = from_fen("r1bqkbnr/pppp1ppp/2n5/4p3/8/2BP1N2/PPP1PPPP/RNBQK2R w KQkq - 0 1");
+        const auto position = from_fen("r1bqkbnr/pppp1ppp/2n5/4p3/8/2BP1N2/PPP1PPPP/RNBQK2R w KQkq - 0 1")
+                                  .value();
 
         const auto move = from_uci(position, "e1g1");
 
@@ -144,7 +149,8 @@ TEST_CASE("UCI notation - castle kingside", TAGS)
 
     SECTION("Black")
     {
-        const auto position = from_fen("rnbqk2r/ppp2ppp/2bp1n2/4p3/2BP4/4PN2/PPP2PPP/RNBQ1RK1 b Qkq - 0 1");
+        const auto position = from_fen("rnbqk2r/ppp2ppp/2bp1n2/4p3/2BP4/4PN2/PPP2PPP/RNBQ1RK1 b Qkq - 0 1")
+                                  .value();
 
         const auto move = from_uci(position, "e8g8");
 
@@ -162,7 +168,8 @@ TEST_CASE("UCI notation - castle queenside", TAGS)
 {
     SECTION("White")
     {
-        const auto position = from_fen("rnb1kb1r/pp1pp1pp/1qp1np2/8/3P1B2/2N5/PPPQPPPP/R3KBNR w KQkq - 0 1");
+        const auto position = from_fen("rnb1kb1r/pp1pp1pp/1qp1np2/8/3P1B2/2N5/PPPQPPPP/R3KBNR w KQkq - 0 1")
+                                  .value();
 
         const auto move = from_uci(position, "e1c1");
 
@@ -177,7 +184,8 @@ TEST_CASE("UCI notation - castle queenside", TAGS)
 
     SECTION("Black")
     {
-        const auto position = from_fen("r3kbnr/pppqpppp/2np4/8/3P1Bb1/2N1P3/PPP2PPP/R2QKBNR b KQkq - 0 1");
+        const auto position = from_fen("r3kbnr/pppqpppp/2np4/8/3P1Bb1/2N1P3/PPP2PPP/R2QKBNR b KQkq - 0 1")
+                                  .value();
 
         const auto move = from_uci(position, "e8c8");
 
@@ -195,7 +203,8 @@ TEST_CASE("UCI notation - promotions", TAGS)
 {
     SECTION("Push")
     {
-        const auto position = from_fen("8/8/2rk4/8/6Q1/1K2N3/2p5/8 b - - 0 1");
+        const auto position = from_fen("8/8/2rk4/8/6Q1/1K2N3/2p5/8 b - - 0 1")
+                                  .value();
 
         const auto move = from_uci(position, "c2c1b");
 
@@ -211,7 +220,8 @@ TEST_CASE("UCI notation - promotions", TAGS)
 
     SECTION("Capture")
     {
-        const auto position = from_fen("4r3/1k1K1P2/8/2qN4/8/8/8/8 w - - 0 1");
+        const auto position = from_fen("4r3/1k1K1P2/8/2qN4/8/8/8/8 w - - 0 1")
+                                  .value();
 
         const auto move = from_uci(position, "f7g8q");
 


### PR DESCRIPTION
- [x] check for null moves when parsing UCI position command
- [x] `pieces::from_string()`
- [x] `rank_from_char()`
- [x] `file_from_char()`
- [x] `Square::from_string()`
- [x] Update coding standards doc