### PR TITLE
fix: flushing `cout` where necessary

### DIFF
--- a/libbenbot/src/search/Callbacks.cpp
+++ b/libbenbot/src/search/Callbacks.cpp
@@ -13,7 +13,6 @@
  */
 
 #include <functional>
-#include <iostream>
 #include <libbenbot/search/Callbacks.hpp>
 #include <libbenbot/search/Context.hpp>
 #include <libchess/uci/Printing.hpp>
@@ -39,13 +38,6 @@ namespace {
             uci_printing::best_move(
                 res.bestMove,
                 transTable.get_best_response(currPos, res.bestMove));
-
-            // Because these callbacks are executed on the searcher background thread,
-            // without this flush here, the output may not actually be written when we
-            // expect, leading to timeouts or GUIs thinking we've hung/disconnected.
-            // Because the best move is always printed last after all info output, we
-            // can do the flush only in this branch.
-            std::cout.flush();
         }
     }
 

--- a/libchess/src/uci/EngineBase.cpp
+++ b/libchess/src/uci/EngineBase.cpp
@@ -53,7 +53,6 @@ void EngineBase::handle_command(std::string_view command)
             wait();
 
         println("readyok");
-        std::cout.flush(); // make sure GUI gets our response
         return;
     }
 
@@ -124,8 +123,6 @@ void EngineBase::respond_to_uci()
         println("{}", option->get_declaration_string());
 
     println("uciok");
-
-    std::cout.flush(); // make sure GUI gets our response
 }
 
 void EngineBase::handle_setpos(const string_view arguments)

--- a/libchess/src/uci/EngineBase.cpp
+++ b/libchess/src/uci/EngineBase.cpp
@@ -53,6 +53,7 @@ void EngineBase::handle_command(std::string_view command)
             wait();
 
         println("readyok");
+        std::cout.flush(); // make sure GUI gets our response
         return;
     }
 
@@ -123,6 +124,8 @@ void EngineBase::respond_to_uci()
         println("{}", option->get_declaration_string());
 
     println("uciok");
+
+    std::cout.flush(); // make sure GUI gets our response
 }
 
 void EngineBase::handle_setpos(const string_view arguments)
@@ -137,26 +140,26 @@ void EngineBase::handle_setpos(const string_view arguments)
 
     using MaybeError = std::expected<void, std::string>;
 
-    parse_position_options(arguments)
-        .and_then([this](const Position& pos) -> MaybeError {
-            if (const auto errorStr = pos.is_illegal()) {
-                [[unlikely]];
-                return std::unexpected(
-                    std::format("Position is illegal: {}", errorStr.value()));
-            }
+    [[maybe_unused]] const auto obj = parse_position_options(arguments)
+                                          .and_then([this](const Position& pos) -> MaybeError {
+                                              if (const auto errorStr = pos.is_illegal()) {
+                                                  [[unlikely]];
+                                                  return std::unexpected(
+                                                      std::format("Position is illegal: {}", errorStr.value()));
+                                              }
 
-            position = pos;
+                                              position = pos;
 
-            set_position(pos);
+                                              set_position(pos);
 
-            return {};
-        })
-        .or_else([this](const std::string_view error) -> MaybeError {
-            info_string(std::format("Error setting position: {}", error));
-            info_string(std::format("Retained previous position: {}", notation::to_fen(position)));
+                                              return {};
+                                          })
+                                          .or_else([this](const std::string_view error) -> MaybeError {
+                                              info_string(std::format("Error setting position: {}", error));
+                                              info_string(std::format("Retained previous position: {}", notation::to_fen(position)));
 
-            return {};
-        });
+                                              return {};
+                                          });
 }
 
 void EngineBase::handle_setoption(const string_view arguments)

--- a/libchess/src/uci/Printing.cpp
+++ b/libchess/src/uci/Printing.cpp
@@ -14,6 +14,7 @@
 
 #include <cmath>
 #include <format>
+#include <iostream>
 #include <libchess/moves/MoveGen.hpp>
 #include <libchess/notation/UCI.hpp>
 #include <libchess/uci/Printing.hpp>
@@ -46,6 +47,8 @@ void best_move(
     std::println(
         "bestmove {}{}",
         to_uci(bestMove), ponder_move_string(ponderMove));
+
+    std::cout.flush(); // make sure the GUI doesn't think we've stalled
 }
 
 namespace {


### PR DESCRIPTION
Sometimes GCC builds in CI appear to hang after the initial `uci` command from the GUI, which seems to indicate that the engine's response isn't recieved/processed by the GUI.